### PR TITLE
Python 3 Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 venv
+*.egg-info
+fantasm-*.tar.gz

--- a/applications/blobstore_migration/blobstore_migration_fsm.py
+++ b/applications/blobstore_migration/blobstore_migration_fsm.py
@@ -21,7 +21,7 @@ system.
 
 TODO: User code to resolve source blobs (via source email links) to the target blobs.
 """
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 from fantasm.action import DatastoreContinuationFSMAction
 from fantasm.action import FSMAction
@@ -75,7 +75,7 @@ class Send( DatastoreContinuationFSMAction ):
             
             # trigger a pull state machine on the target app
             response = urlfetch.fetch(startPullUrl, 
-                                      payload=urllib.urlencode({SOURCE_BLOB_KEY_PARAM: str(sourceBlobInfo.key()),
+                                      payload=urllib.parse.urlencode({SOURCE_BLOB_KEY_PARAM: str(sourceBlobInfo.key()),
                                                                 SOURCE_BLOB_FILENAME_PARAM: sourceBlobInfo.filename,
                                                                 SOURCE_BLOB_CONTENT_TYPE_PARAM: sourceBlobInfo.content_type,
                                                                 SOURCE_HOST_PARAM: sourceHost,

--- a/applications/blobstore_migration/main.py
+++ b/applications/blobstore_migration/main.py
@@ -64,8 +64,8 @@ class StartMigrationHandler(webapp.RequestHandler):
     
     def post(self):
         """ see RequestHandler.post() """
-        assert SOURCE_HOST_PARAM in self.request.POST.keys()
-        assert TARGET_HOST_PARAM in self.request.POST.keys()
+        assert SOURCE_HOST_PARAM in list(self.request.POST.keys())
+        assert TARGET_HOST_PARAM in list(self.request.POST.keys())
         
         # using one-time taskName ensure we don't start the migration twice
         taskName = self.request.POST.get(TASK_NAME_PARAM, DEFAULT_TASK_NAME)

--- a/applications/blobstore_migration/main.py
+++ b/applications/blobstore_migration/main.py
@@ -54,8 +54,8 @@ class StartMigrationHandler(webapp.RequestHandler):
     def get(self):
         """ see RequestHandler.get() """
         version = os.environ['CURRENT_VERSION_ID'].split('.')[0]
-        sourceHost = '%s.FIXME_SOURCE.appspot.com' % (version,)
-        targetHost = '%s.FIXME_TARGET.appspot.com' % (version,)
+        sourceHost = '{}.FIXME_SOURCE.appspot.com'.format(version)
+        targetHost = '{}.FIXME_TARGET.appspot.com'.format(version)
         content = CONTENT % {SOURCE_HOST_PARAM: sourceHost,
                              TARGET_HOST_PARAM: targetHost,
                              TASK_NAME_PARAM: DEFAULT_TASK_NAME,

--- a/applications/logcollector/main.py
+++ b/applications/logcollector/main.py
@@ -47,10 +47,10 @@ class StartLogCollectorHandler(webapp.RequestHandler):
     
     def post(self):
         """ see RequestHandler.post() """
-        assert VERSION_IDS_PARAM in self.request.POST.keys(), "Require deployed version to monitor."
+        assert VERSION_IDS_PARAM in list(self.request.POST.keys()), "Require deployed version to monitor."
         assert self.request.POST[VERSION_IDS_PARAM] != CURRENT_VERSION_ID, "Cannot monitor own version."
-        assert SENDER_EMAIL_PARAM in self.request.POST.keys(), "Require admin sender email address."
-        assert TO_EMAIL_PARAM in self.request.POST.keys(), "Require email address."
+        assert SENDER_EMAIL_PARAM in list(self.request.POST.keys()), "Require admin sender email address."
+        assert TO_EMAIL_PARAM in list(self.request.POST.keys()), "Require email address."
         fantasm.startStateMachine(LOG_COLLECTOR_MACHINE_NAME, [self.request.POST])
         self.response.out.write("LogCollector started on version '%s'." % self.request.POST[VERSION_IDS_PARAM])
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+--extra-index-url https://us-central1-python.pkg.dev/repcore-prod/python/simple/
+appengine-python-standard==1.1.5
+keyrings.google-artifactregistry-auth==1.1.2
+twine==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 --extra-index-url https://us-central1-python.pkg.dev/repcore-prod/python/simple/
 appengine-python-standard==1.1.5
 keyrings.google-artifactregistry-auth==1.1.2
+PyYAML==6.0.1
 twine==4.0.2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="fantasm",
+    version="2.0.0",
+    packages=find_packages(where="src"),
+    url="http://github.com/vendasta/fantasm",
+    install_requires=[
+        "appengine-python-standard==1.1.5",
+        "PyYAML==6.0.1",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="fantasm",
     version="2.0.0",
-    packages=find_packages(where="src"),
+    packages=find_packages(where="src/fantasm"),
     url="http://github.com/vendasta/fantasm",
     install_requires=[
         "appengine-python-standard==1.1.5",

--- a/src/fantasm/action.py
+++ b/src/fantasm/action.py
@@ -26,7 +26,7 @@ from fantasm.constants import CONTINUATION_COMPLETE_PARAM
 from fantasm.constants import STEPS_PARAM
 from fantasm.constants import GEN_PARAM
 
-class FSMAction(object):
+class FSMAction:
     """ Defines the interface for all user actions. """
 
     def execute(self, context, obj):

--- a/src/fantasm/config.py
+++ b/src/fantasm/config.py
@@ -98,7 +98,7 @@ def loadYaml(filename=None, importedAlready=None, rootUrl=None, enableCapabiliti
 
     try:
         yamlFile = open(filename)
-    except IOError:
+    except OSError:
         raise exceptions.YamlFileNotFoundError(filename)
     try:
         configDict = yaml.load(yamlFile.read())
@@ -110,7 +110,7 @@ def loadYaml(filename=None, importedAlready=None, rootUrl=None, enableCapabiliti
                          rootUrl=rootUrl,
                          enableCapabilitiesCheck=enableCapabilitiesCheck)
 
-class Configuration(object):
+class Configuration:
     """ An overall configuration that corresponds to a fantasm.yaml file. """
 
     def __init__(self, configDict, importedAlready=None, rootUrl=None, enableCapabilitiesCheck=None):
@@ -262,7 +262,7 @@ def _resolveClass(className, namespace):
     if '.' in className:
         fullyQualifiedClass = className
     elif namespace:
-        fullyQualifiedClass = '%s.%s' % (namespace, className)
+        fullyQualifiedClass = '{}.{}'.format(namespace, className)
     else:
         fullyQualifiedClass = className
 
@@ -308,7 +308,7 @@ def _resolveObject(objectName, namespace, expectedType=str):
 
     return resolvedObject
 
-class _MachineConfig(object):
+class _MachineConfig:
     """ Configuration of a machine. """
 
     def __init__(self, initDict, rootUrl=None):
@@ -426,9 +426,9 @@ class _MachineConfig(object):
     @property
     def url(self):
         """ Returns the url for this machine. """
-        return '%sfsm/%s/' % (self.rootUrl, self.name)
+        return '{}fsm/{}/'.format(self.rootUrl, self.name)
 
-class _StateConfig(object):
+class _StateConfig:
     """ Configuration of a state. """
 
     # R0912:268:_StateConfig.__init__: Too many branches (22/20)
@@ -525,7 +525,7 @@ class _StateConfig(object):
         else:
             self.exit = None
 
-class _TransitionConfig(object):
+class _TransitionConfig:
     """ Configuration of a transition. """
 
     # R0912:326:_TransitionConfig.__init__: Too many branches (22/20)
@@ -557,7 +557,7 @@ class _TransitionConfig(object):
             raise exceptions.InvalidTransitionEventNameError(self.machineName, fromStateName, self.event)
 
         # transition name
-        self.name = '%s--%s' % (fromStateName, self.event)
+        self.name = '{}--{}'.format(fromStateName, self.event)
         if not self.name:
             raise exceptions.TransitionNameRequiredError(self.machineName)
         if not constants.NAME_RE.match(self.name):

--- a/src/fantasm/config.py
+++ b/src/fantasm/config.py
@@ -18,20 +18,17 @@ Copyright 2010 VendAsta Technologies Inc.
 """
 
 
-import os
-import yaml
-import logging
-import sys
-
-if sys.version_info < (2, 7):
-    import simplejson as json
-else:
-    import json
-
 import datetime
+import json
+import logging
+import os
 import pickle
+import sys
 import threading
-from fantasm import exceptions, constants, utils
+
+import yaml
+
+from fantasm import constants, exceptions, utils
 
 TASK_ATTRIBUTES = (
     (constants.TASK_RETRY_LIMIT_ATTRIBUTE, 'taskRetryLimit', constants.DEFAULT_TASK_RETRY_LIMIT,

--- a/src/fantasm/config.py
+++ b/src/fantasm/config.py
@@ -16,7 +16,7 @@ Copyright 2010 VendAsta Technologies Inc.
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from __future__ import with_statement
+
 
 import os
 import yaml
@@ -175,7 +175,7 @@ class Configuration(object):
 
     def __addMachinesFromImportedConfig(self, importedCofig):
         """ Adds new machines from an imported configuration. """
-        for machineName, machine in importedCofig.machines.items():
+        for machineName, machine in list(importedCofig.machines.items()):
             if machineName in self.machines:
                 raise exceptions.MachineNameNotUniqueError(machineName)
             self.machines[machineName] = machine
@@ -227,12 +227,12 @@ def _resolveClass(className, namespace):
     shortTypes = {
         # basestring types
         'str': str,
-        'unicode': unicode,
+        'unicode': str,
 
         # numeric types
         'int': int,
         'float': float,
-        'long': long,
+        'long': int,
 
         # bool('False') does not work as expected, so this helper function facilitates the conversions
         'bool': utils.boolConverter,
@@ -271,7 +271,7 @@ def _resolveClass(className, namespace):
 
     try:
         module = __import__(moduleName, globals(), locals(), [className])
-    except ImportError, e:
+    except ImportError as e:
         raise exceptions.UnknownModuleError(moduleName, e)
 
     try:
@@ -280,7 +280,7 @@ def _resolveClass(className, namespace):
     except AttributeError:
         raise exceptions.UnknownClassError(moduleName, className)
 
-def _resolveObject(objectName, namespace, expectedType=basestring):
+def _resolveObject(objectName, namespace, expectedType=str):
     """ Given a string name/path of a object, locates and returns the value of the object.
 
     @param objectName: ie. MODULE_LEVEL_CONSTANT, ActionName.CLASS_LEVEL_CONSTANT
@@ -325,7 +325,7 @@ class _MachineConfig(object):
 
         # check for bad attributes
         badAttributes = set()
-        for attribute in initDict.iterkeys():
+        for attribute in initDict.keys():
             if attribute not in constants.VALID_MACHINE_ATTRIBUTES:
                 badAttributes.add(attribute)
         if badAttributes:
@@ -378,7 +378,7 @@ class _MachineConfig(object):
         # context types
         self.contextTypes = {}
         contextTypes = initDict.get(constants.MACHINE_CONTEXT_TYPES_ATTRIBUTE, {})
-        for contextName, contextType in contextTypes.iteritems():
+        for contextName, contextType in contextTypes.items():
             try:
                 # attempt to import the value of the event
                 contextKey = _resolveObject(contextName, self.namespace)
@@ -446,7 +446,7 @@ class _StateConfig(object):
 
         # check for bad attributes
         badAttributes = set()
-        for attribute in stateDict.iterkeys():
+        for attribute in stateDict.keys():
             if attribute not in constants.VALID_STATE_ATTRIBUTES:
                 badAttributes.add(attribute)
         if badAttributes:
@@ -537,7 +537,7 @@ class _TransitionConfig(object):
 
         # check for bad attributes
         badAttributes = set()
-        for attribute in transDict.iterkeys():
+        for attribute in transDict.keys():
             if attribute not in constants.VALID_TRANS_ATTRIBUTES:
                 badAttributes.add(attribute)
         if badAttributes:

--- a/src/fantasm/config.py
+++ b/src/fantasm/config.py
@@ -18,12 +18,10 @@ Copyright 2010 VendAsta Technologies Inc.
 """
 
 
-import datetime
 import json
 import logging
 import os
 import pickle
-import sys
 import threading
 
 import yaml
@@ -84,6 +82,12 @@ def _findYaml(yamlNames=constants.YAML_NAMES):
         if parent == directory:
             break
         directory = parent
+    pwd = os.environ.get('PWD')
+    if pwd and pwd != directory:
+        for yamlName in yamlNames:
+            yamlPath = os.path.join(pwd, yamlName)
+            if os.path.exists(yamlPath):
+                return yamlPath
     return None
 
 def loadYaml(filename=None, importedAlready=None, rootUrl=None, enableCapabilitiesCheck=None):
@@ -98,7 +102,7 @@ def loadYaml(filename=None, importedAlready=None, rootUrl=None, enableCapabiliti
     except OSError:
         raise exceptions.YamlFileNotFoundError(filename)
     try:
-        configDict = yaml.load(yamlFile.read())
+        configDict = yaml.safe_load(yamlFile.read())
     finally:
         yamlFile.close()
 

--- a/src/fantasm/constants.py
+++ b/src/fantasm/constants.py
@@ -17,14 +17,9 @@ Copyright 2010 VendAsta Technologies Inc.
    limitations under the License.
 """
 
+import json
 import os
 import re
-import sys
-
-if sys.version_info < (2, 7):
-    import simplejson as json
-else:
-    import json
 
 # these parameters are not stored in the FSMContext, but are used to drive the fantasm task/event dispatching mechanism
 STATE_PARAM = '__st__'

--- a/src/fantasm/exceptions.py
+++ b/src/fantasm/exceptions.py
@@ -51,7 +51,7 @@ class HaltMachineError(Exception):
     def __init__(self, message, logLevel=logging.WARNING):
         self.message = message
         self.level = logLevel
-        super(HaltMachineError, self).__init__(message)
+        super().__init__(message)
 
 class FSMRuntimeError(Exception):
     """ The parent class of all Fantasm runtime errors. """
@@ -62,21 +62,21 @@ class UnknownMachineError(FSMRuntimeError):
     def __init__(self, machineName):
         """ Initialize exception """
         message = 'Cannot find machine "%s".' % machineName
-        super(UnknownMachineError, self).__init__(message)
+        super().__init__(message)
 
 class UnknownStateError(FSMRuntimeError):
     """ A state could not be found  """
     def __init__(self, machineName, stateName):
         """ Initialize exception """
-        message = 'State "%s" is unknown. (Machine %s)' % (stateName, machineName)
-        super(UnknownStateError, self).__init__(message)
+        message = 'State "{}" is unknown. (Machine {})'.format(stateName, machineName)
+        super().__init__(message)
 
 class UnknownEventError(FSMRuntimeError):
     """ An event and the transition bound to it could not be found. """
     def __init__(self, event, machineName, stateName):
         """ Initialize exception """
-        message = 'Cannot find transition for event "%s". (Machine %s, State %s)' % (event, machineName, stateName)
-        super(UnknownEventError, self).__init__(message)
+        message = 'Cannot find transition for event "{}". (Machine {}, State {})'.format(event, machineName, stateName)
+        super().__init__(message)
 
 class InvalidEventNameRuntimeError(FSMRuntimeError):
     """ Event returned from dispatch is invalid (and would cause problems with task name restrictions). """
@@ -85,7 +85,7 @@ class InvalidEventNameRuntimeError(FSMRuntimeError):
         message = 'Event "%r" returned by state is invalid. It must be a string and match pattern "%s". ' \
                   '(Machine %s, State %s, Instance %s)' % \
                   (event, constants.NAME_PATTERN, machineName, stateName, instanceName)
-        super(InvalidEventNameRuntimeError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidFinalEventRuntimeError(FSMRuntimeError):
     """ Event returned when a final state action returns an event. """
@@ -94,7 +94,7 @@ class InvalidFinalEventRuntimeError(FSMRuntimeError):
         message = 'Event "%r" returned by final state is invalid. ' \
                   '(Machine %s, State %s, Instance %s)' % \
                   (event, machineName, stateName, instanceName)
-        super(InvalidFinalEventRuntimeError, self).__init__(message)
+        super().__init__(message)
 
 class FanInWriteLockFailureRuntimeError(FSMRuntimeError):
     """ Exception when fan-in writers are unable to acquire a lock. """
@@ -103,7 +103,7 @@ class FanInWriteLockFailureRuntimeError(FSMRuntimeError):
         message = 'Event "%r" unable to to be fanned-in due to write lock failure. ' \
                   '(Machine %s, State %s, Instance %s)' % \
                   (event, machineName, stateName, instanceName)
-        super(FanInWriteLockFailureRuntimeError, self).__init__(message)
+        super().__init__(message)
 
 class FanInReadLockFailureRuntimeError(FSMRuntimeError):
     """ Exception when fan-in readers are unable to acquire a lock. """
@@ -112,7 +112,7 @@ class FanInReadLockFailureRuntimeError(FSMRuntimeError):
         message = 'Event "%r" unable to to be fanned-in due to read lock failure. ' \
                   '(Machine %s, State %s, Instance %s)' % \
                   (event, machineName, stateName, instanceName)
-        super(FanInReadLockFailureRuntimeError, self).__init__(message)
+        super().__init__(message)
 
 class FanInNoContextsAvailableRuntimeError(FSMRuntimeError):
     """ Exception when fan-in results in 0 contexts - ie. appengine index write timing issue. """
@@ -120,7 +120,7 @@ class FanInNoContextsAvailableRuntimeError(FSMRuntimeError):
         """ Initialize exception """
         message = 'Fan-in resulted in 0 contexts. (Event %s, Machine %s, State %s, Instance %s)' % \
                   (event, machineName, stateName, instanceName)
-        super(FanInNoContextsAvailableRuntimeError, self).__init__(message)
+        super().__init__(message)
 
 class RequiredServicesUnavailableRuntimeError(FSMRuntimeError):
     """ Some of the required API services are not available. """
@@ -128,7 +128,7 @@ class RequiredServicesUnavailableRuntimeError(FSMRuntimeError):
         """ Initialize exception """
         message = 'The following services will not be available in the %d seconds: %s. This task will be retried.' % \
                   (constants.REQUEST_LENGTH, unavailableServices)
-        super(RequiredServicesUnavailableRuntimeError, self).__init__(message)
+        super().__init__(message)
 
 class ConfigurationError(Exception):
     """ Parent class for all Fantasm configuration errors. """
@@ -139,77 +139,77 @@ class YamlFileNotFoundError(ConfigurationError):
     def __init__(self, filename):
         """ Initialize exception """
         message = 'Yaml configuration file "%s" not found.' % filename
-        super(YamlFileNotFoundError, self).__init__(message)
+        super().__init__(message)
 
 class YamlFileCircularImportError(ConfigurationError):
     """ The Yaml is involved in a circular import. """
     def __init__(self, filename):
         """ Initialize exception """
         message = 'Yaml configuration file "%s" involved in a circular import.' % filename
-        super(YamlFileCircularImportError, self).__init__(message)
+        super().__init__(message)
 
 class StateMachinesAttributeRequiredError(ConfigurationError):
     """ The YAML file requires a 'state_machines' attribute. """
     def __init__(self):
         """ Initialize exception """
         message = '"%s" is required attribute of yaml file.' % constants.STATE_MACHINES_ATTRIBUTE
-        super(StateMachinesAttributeRequiredError, self).__init__(message)
+        super().__init__(message)
 
 class MachineNameRequiredError(ConfigurationError):
     """ Each machine requires a name. """
     def __init__(self):
         """ Initialize exception """
         message = '"%s" is required attribute of machine.' % constants.MACHINE_NAME_ATTRIBUTE
-        super(MachineNameRequiredError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidQueueNameError(ConfigurationError):
     """ The queue name was not valid. """
     def __init__(self, queueName, machineName):
         """ Initialize exception """
-        message = 'Queue name "%s" must exist in queue.yaml. (Machine %s)' % (queueName, machineName)
-        super(InvalidQueueNameError, self).__init__(message)
+        message = 'Queue name "{}" must exist in queue.yaml. (Machine {})'.format(queueName, machineName)
+        super().__init__(message)
 
 class InvalidMachineNameError(ConfigurationError):
     """ The machine name was not valid. """
     def __init__(self, machineName):
         """ Initialize exception """
-        message = 'Machine name must match pattern "%s". (Machine %s)' % (constants.NAME_PATTERN, machineName)
-        super(InvalidMachineNameError, self).__init__(message)
+        message = 'Machine name must match pattern "{}". (Machine {})'.format(constants.NAME_PATTERN, machineName)
+        super().__init__(message)
 
 class MachineNameNotUniqueError(ConfigurationError):
     """ Each machine in a YAML file must have a unique name. """
     def __init__(self, machineName):
         """ Initialize exception """
         message = 'Machine names must be unique. (Machine %s)' % machineName
-        super(MachineNameNotUniqueError, self).__init__(message)
+        super().__init__(message)
 
 class MachineHasMultipleInitialStatesError(ConfigurationError):
     """ Each machine must have exactly one initial state. """
     def __init__(self, machineName):
         """ Initialize exception """
         message = 'Machine has multiple initial states, but only one is allowed. (Machine %s)' % machineName
-        super(MachineHasMultipleInitialStatesError, self).__init__(message)
+        super().__init__(message)
 
 class MachineHasNoInitialStateError(ConfigurationError):
     """ Each machine must have exactly one initial state. """
     def __init__(self, machineName):
         """ Initialize exception """
         message = 'Machine has no initial state, exactly one is required. (Machine %s)' % machineName
-        super(MachineHasNoInitialStateError, self).__init__(message)
+        super().__init__(message)
 
 class MachineHasNoFinalStateError(ConfigurationError):
     """ Each machine must have at least one final state. """
     def __init__(self, machineName):
         """ Initialize exception """
         message = 'Machine has no final states, but at least one is required. (Machine %s)' % machineName
-        super(MachineHasNoFinalStateError, self).__init__(message)
+        super().__init__(message)
 
 class StateNameRequiredError(ConfigurationError):
     """ Each state requires a name. """
     def __init__(self, machineName):
         """ Initialize exception """
-        message = '"%s" is required attribute of state. (Machine %s)' % (constants.STATE_NAME_ATTRIBUTE, machineName)
-        super(StateNameRequiredError, self).__init__(message)
+        message = '"{}" is required attribute of state. (Machine {})'.format(constants.STATE_NAME_ATTRIBUTE, machineName)
+        super().__init__(message)
 
 class InvalidStateNameError(ConfigurationError):
     """ The state name was not valid. """
@@ -217,7 +217,7 @@ class InvalidStateNameError(ConfigurationError):
         """ Initialize exception """
         message = 'State name must match pattern "%s". (Machine %s, State %s)' % \
                   (constants.NAME_PATTERN, machineName, stateName)
-        super(InvalidStateNameError, self).__init__(message)
+        super().__init__(message)
 
 class StateNameNotUniqueError(ConfigurationError):
     """ Each state within a machine must have a unique name. """
@@ -225,7 +225,7 @@ class StateNameNotUniqueError(ConfigurationError):
         """ Initialize exception """
         message = 'State names within a machine must be unique. (Machine %s, State %s)' % \
                   (machineName, stateName)
-        super(StateNameNotUniqueError, self).__init__(message)
+        super().__init__(message)
 
 class StateActionRequired(ConfigurationError):
     """ Each state requires an action. """
@@ -233,35 +233,35 @@ class StateActionRequired(ConfigurationError):
         """ Initialize exception """
         message = '"%s" is required attribute of state. (Machine %s, State %s)' % \
                   (constants.STATE_ACTION_ATTRIBUTE, machineName, stateName)
-        super(StateActionRequired, self).__init__(message)
+        super().__init__(message)
 
 class UnknownModuleError(ConfigurationError):
     """ When resolving actions, the module was not found. """
     def __init__(self, moduleName, importError):
         """ Initialize exception """
-        message = 'Module "%s" cannot be imported due to "%s".' % (moduleName, importError)
-        super(UnknownModuleError, self).__init__(message)
+        message = 'Module "{}" cannot be imported due to "{}".'.format(moduleName, importError)
+        super().__init__(message)
 
 class UnknownClassError(ConfigurationError):
     """ When resolving actions, the class was not found. """
     def __init__(self, moduleName, className):
         """ Initialize exception """
-        message = 'Class "%s" was not found in module "%s".' % (className, moduleName)
-        super(UnknownClassError, self).__init__(message)
+        message = 'Class "{}" was not found in module "{}".'.format(className, moduleName)
+        super().__init__(message)
 
 class UnknownObjectError(ConfigurationError):
     """ When resolving actions, the object was not found. """
     def __init__(self, objectName):
         """ Initialize exception """
         message = 'Object "%s" was not found.' % (objectName)
-        super(UnknownObjectError, self).__init__(message)
+        super().__init__(message)
 
 class UnexpectedObjectTypeError(ConfigurationError):
     """ When resolving actions, the object was not found. """
     def __init__(self, objectName, expectedType):
         """ Initialize exception """
-        message = 'Object "%s" is not of type "%s".' % (objectName, expectedType)
-        super(UnexpectedObjectTypeError, self).__init__(message)
+        message = 'Object "{}" is not of type "{}".'.format(objectName, expectedType)
+        super().__init__(message)
 
 class InvalidMaxRetriesError(ConfigurationError):
     """ max_retries must be a positive integer. """
@@ -269,7 +269,7 @@ class InvalidMaxRetriesError(ConfigurationError):
         """ Initialize exception """
         message = '%s "%s" is invalid. Must be an integer. (Machine %s)' % \
                   (constants.MAX_RETRIES_ATTRIBUTE, maxRetries, machineName)
-        super(InvalidMaxRetriesError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidTaskRetryLimitError(ConfigurationError):
     """ task_retry_limit must be a positive integer. """
@@ -277,7 +277,7 @@ class InvalidTaskRetryLimitError(ConfigurationError):
         """ Initialize exception """
         message = '%s "%s" is invalid. Must be an integer. (Machine %s)' % \
                   (constants.TASK_RETRY_LIMIT_ATTRIBUTE, taskRetryLimit, machineName)
-        super(InvalidTaskRetryLimitError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidMinBackoffSecondsError(ConfigurationError):
     """ min_backoff_seconds must be a positive integer. """
@@ -285,7 +285,7 @@ class InvalidMinBackoffSecondsError(ConfigurationError):
         """ Initialize exception """
         message = '%s "%s" is invalid. Must be an integer. (Machine %s)' % \
                   (constants.MIN_BACKOFF_SECONDS_ATTRIBUTE, minBackoffSeconds, machineName)
-        super(InvalidMinBackoffSecondsError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidMaxBackoffSecondsError(ConfigurationError):
     """ max_backoff_seconds must be a positive integer. """
@@ -293,7 +293,7 @@ class InvalidMaxBackoffSecondsError(ConfigurationError):
         """ Initialize exception """
         message = '%s "%s" is invalid. Must be an integer. (Machine %s)' % \
                   (constants.MAX_BACKOFF_SECONDS_ATTRIBUTE, maxBackoffSeconds, machineName)
-        super(InvalidMaxBackoffSecondsError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidTaskAgeLimitError(ConfigurationError):
     """ task_age_limit must be a positive integer. """
@@ -301,7 +301,7 @@ class InvalidTaskAgeLimitError(ConfigurationError):
         """ Initialize exception """
         message = '%s "%s" is invalid. Must be an integer. (Machine %s)' % \
                   (constants.TASK_AGE_LIMIT_ATTRIBUTE, taskAgeLimit, machineName)
-        super(InvalidTaskAgeLimitError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidMaxDoublingsError(ConfigurationError):
     """ max_doublings must be a positive integer. """
@@ -309,7 +309,7 @@ class InvalidMaxDoublingsError(ConfigurationError):
         """ Initialize exception """
         message = '%s "%s" is invalid. Must be an integer. (Machine %s)' % \
                   (constants.MAX_DOUBLINGS_ATTRIBUTE, maxDoublings, machineName)
-        super(InvalidMaxDoublingsError, self).__init__(message)
+        super().__init__(message)
 
 class MaxRetriesAndTaskRetryLimitMutuallyExclusiveError(ConfigurationError):
     """ max_retries and task_retry_limit cannot both be specified on a machine. """
@@ -317,7 +317,7 @@ class MaxRetriesAndTaskRetryLimitMutuallyExclusiveError(ConfigurationError):
         """ Initialize exception """
         message = 'max_retries and task_retry_limit cannot both be specified on a machine. (Machine %s)' % \
                   machineName
-        super(MaxRetriesAndTaskRetryLimitMutuallyExclusiveError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidLoggingError(ConfigurationError):
     """ The logging value was not valid. """
@@ -325,7 +325,7 @@ class InvalidLoggingError(ConfigurationError):
         """ Initialize exception """
         message = 'logging attribute "%s" is invalid (must be one of "%s"). (Machine %s)' % \
                   (loggingValue, constants.VALID_LOGGING_VALUES, machineName)
-        super(InvalidLoggingError, self).__init__(message)
+        super().__init__(message)
 
 class TransitionNameRequiredError(ConfigurationError):
     """ Each transition requires a name. """
@@ -333,7 +333,7 @@ class TransitionNameRequiredError(ConfigurationError):
         """ Initialize exception """
         message = '"%s" is required attribute of transition. (Machine %s)' % \
                   (constants.TRANS_NAME_ATTRIBUTE, machineName)
-        super(TransitionNameRequiredError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidTransitionNameError(ConfigurationError):
     """ The transition name was invalid. """
@@ -341,7 +341,7 @@ class InvalidTransitionNameError(ConfigurationError):
         """ Initialize exception """
         message = 'Transition name must match pattern "%s". (Machine %s, Transition %s)' % \
                   (constants.NAME_PATTERN, machineName, transitionName)
-        super(InvalidTransitionNameError, self).__init__(message)
+        super().__init__(message)
 
 class TransitionNameNotUniqueError(ConfigurationError):
     """ Each transition within a machine must have a unique name. """
@@ -349,7 +349,7 @@ class TransitionNameNotUniqueError(ConfigurationError):
         """ Initialize exception """
         message = 'Transition names within a machine must be unique. (Machine %s, Transition %s)' % \
                   (machineName, transitionName)
-        super(TransitionNameNotUniqueError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidTransitionEventNameError(ConfigurationError):
     """ The transition's event name was invalid. """
@@ -357,7 +357,7 @@ class InvalidTransitionEventNameError(ConfigurationError):
         """ Initialize exception """
         message = 'Transition event name must match pattern "%s". (Machine %s, State %s, Event %s)' % \
                   (constants.NAME_PATTERN, machineName, fromStateName, eventName)
-        super(InvalidTransitionEventNameError, self).__init__(message)
+        super().__init__(message)
 
 class TransitionUnknownToStateError(ConfigurationError):
     """ Each transition must specify a to state. """
@@ -365,7 +365,7 @@ class TransitionUnknownToStateError(ConfigurationError):
         """ Initialize exception """
         message = 'Transition to state is undefined. (Machine %s, Transition %s, To %s)' % \
                   (machineName, transitionName, toState)
-        super(TransitionUnknownToStateError, self).__init__(message)
+        super().__init__(message)
 
 class TransitionToRequiredError(ConfigurationError):
     """ The specified to state is unknown. """
@@ -373,7 +373,7 @@ class TransitionToRequiredError(ConfigurationError):
         """ Initialize exception """
         message = '"%s" is required attribute of transition. (Machine %s, Transition %s)' % \
                   (constants.TRANS_TO_ATTRIBUTE, machineName, transitionName)
-        super(TransitionToRequiredError, self).__init__(message)
+        super().__init__(message)
 
 class TransitionEventRequiredError(ConfigurationError):
     """ Each transition requires an event to be bound to. """
@@ -381,7 +381,7 @@ class TransitionEventRequiredError(ConfigurationError):
         """ Initialize exception """
         message = '"%s" is required attribute of transition. (Machine %s, State %s)' % \
                   (constants.TRANS_EVENT_ATTRIBUTE, machineName, fromStateName)
-        super(TransitionEventRequiredError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidCountdownError(ConfigurationError):
     """ Countdown must be a positive integer. """
@@ -391,7 +391,7 @@ class InvalidCountdownError(ConfigurationError):
                    '(Machine %s, State %s)') % \
                   (countdown, constants.COUNTDOWN_MINIMUM_ATTRIBUTE, constants.COUNTDOWN_MAXIMUM_ATTRIBUTE,
                    machineName, fromStateName)
-        super(InvalidCountdownError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidMachineAttributeError(ConfigurationError):
     """ Unknown machine attributes were found. """
@@ -399,7 +399,7 @@ class InvalidMachineAttributeError(ConfigurationError):
         """ Initialize exception """
         message = 'The following are invalid attributes a machine: %s. (Machine %s)' % \
                   (badAttributes, machineName)
-        super(InvalidMachineAttributeError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidStateAttributeError(ConfigurationError):
     """ Unknown state attributes were found. """
@@ -407,7 +407,7 @@ class InvalidStateAttributeError(ConfigurationError):
         """ Initialize exception """
         message = 'The following are invalid attributes a state: %s. (Machine %s, State %s)' % \
                   (badAttributes, machineName, stateName)
-        super(InvalidStateAttributeError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidTransitionAttributeError(ConfigurationError):
     """ Unknown transition attributes were found. """
@@ -415,7 +415,7 @@ class InvalidTransitionAttributeError(ConfigurationError):
         """ Initialize exception """
         message = 'The following are invalid attributes a transition: %s. (Machine %s, State %s)' % \
                   (badAttributes, machineName, fromStateName)
-        super(InvalidTransitionAttributeError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidInterfaceError(ConfigurationError):
     """ Interface errors. """
@@ -425,29 +425,29 @@ class InvalidContinuationInterfaceError(InvalidInterfaceError):
     """ The specified state was denoted as a continuation, but it does not have a continuation method. """
     def __init__(self, machineName, stateName):
         message = 'The state was specified as continuation=True, but the action class does not have a ' + \
-                  'continuation() method. (Machine %s, State %s)' % (machineName, stateName)
-        super(InvalidContinuationInterfaceError, self).__init__(message)
+                  'continuation() method. (Machine {}, State {})'.format(machineName, stateName)
+        super().__init__(message)
 
 class InvalidActionInterfaceError(InvalidInterfaceError):
     """ The specified state's action class does not have an execute() method. """
     def __init__(self, machineName, stateName):
         message = 'The state\'s action class does not have an execute() method. (Machine %s, State %s)' % \
                   (machineName, stateName)
-        super(InvalidActionInterfaceError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidEntryInterfaceError(InvalidInterfaceError):
     """ The specified state's entry class does not have an execute() method. """
     def __init__(self, machineName, stateName):
         message = 'The state\'s entry class does not have an execute() method. (Machine %s, State %s)' % \
                   (machineName, stateName)
-        super(InvalidEntryInterfaceError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidExitInterfaceError(InvalidInterfaceError):
     """ The specified state's exit class does not have an execute() method. """
     def __init__(self, machineName, stateName):
         message = 'The state\'s exit class does not have an execute() method. (Machine %s, State %s)' % \
                   (machineName, stateName)
-        super(InvalidExitInterfaceError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidFanInError(ConfigurationError):
     """ fan_in must be a positive integer. """
@@ -455,7 +455,7 @@ class InvalidFanInError(ConfigurationError):
         """ Initialize exception """
         message = '%s "%s" is invalid. Must be an integer. (Machine %s, State %s)' % \
                   (constants.STATE_FAN_IN_ATTRIBUTE, fanInPeriod, machineName, stateName)
-        super(InvalidFanInError, self).__init__(message)
+        super().__init__(message)
 
 class InvalidFanInGroupError(ConfigurationError):
     """ fan_in_group must be a string key. """
@@ -463,7 +463,7 @@ class InvalidFanInGroupError(ConfigurationError):
         """ Initialize exception """
         message = '%s "%s" is invalid. Requires fan_in attribute as well. (Machine %s, State %s)' % \
                   (constants.STATE_FAN_IN_GROUP_ATTRIBUTE, fanInGroup, machineName, stateName)
-        super(InvalidFanInGroupError, self).__init__(message)
+        super().__init__(message)
 
 class FanInContinuationNotSupportedError(ConfigurationError):
     """ Cannot have fan_in and continuation on the same state, because it hurts our head at the moment. """
@@ -472,11 +472,11 @@ class FanInContinuationNotSupportedError(ConfigurationError):
         message = '%s and %s are not supported on the same state. Maybe some day... (Machine %s, State %s)' % \
                   (constants.STATE_CONTINUATION_ATTRIBUTE, constants.STATE_FAN_IN_ATTRIBUTE,
                    machineName, stateName)
-        super(FanInContinuationNotSupportedError, self).__init__(message)
+        super().__init__(message)
 
 class UnsupportedConfigurationError(ConfigurationError):
     """ Some exit and transition actions are not allowed near fan_in and continuation. At least not at the moment. """
     def __init__(self, machineName, stateName, message):
         """ Initialize exception """
-        message = '%s (Machine %s, State %s)' % (message, machineName, stateName)
-        super(UnsupportedConfigurationError, self).__init__(message)
+        message = '{} (Machine {}, State {})'.format(message, machineName, stateName)
+        super().__init__(message)

--- a/src/fantasm/fsm.py
+++ b/src/fantasm/fsm.py
@@ -104,7 +104,7 @@ class FSM(object):
         self.config = currentConfig or config.currentConfiguration()
         self.machines = {}
         self.pseudoInits, self.pseudoFinals = {}, {}
-        for machineConfig in self.config.machines.values():
+        for machineConfig in list(self.config.machines.values()):
             self.machines[machineConfig.name] = {constants.MACHINE_STATES_ATTRIBUTE: {},
                                                  constants.MACHINE_TRANSITIONS_ATTRIBUTE: {}}
             machine = self.machines[machineConfig.name]
@@ -119,7 +119,7 @@ class FSM(object):
             self.pseudoFinals[machineConfig.name] = pseudoFinal
             self.machines[machineConfig.name][constants.MACHINE_STATES_ATTRIBUTE][FSM.PSEUDO_FINAL] = pseudoFinal
 
-            for stateConfig in machineConfig.states.values():
+            for stateConfig in list(machineConfig.states.values()):
                 state = self._getState(machineConfig, stateConfig)
 
                 # add the transition from pseudo-init to initialState
@@ -138,7 +138,7 @@ class FSM(object):
 
                 machine[constants.MACHINE_STATES_ATTRIBUTE][stateConfig.name] = state
 
-            for transitionConfig in machineConfig.transitions.values():
+            for transitionConfig in list(machineConfig.transitions.values()):
                 source = machine[constants.MACHINE_STATES_ATTRIBUTE][transitionConfig.fromState.name]
                 transition = self._getTransition(machineConfig, transitionConfig)
                 machine[constants.MACHINE_TRANSITIONS_ATTRIBUTE][transitionConfig.name] = transition
@@ -500,11 +500,11 @@ class FSMContext(dict):
                     self[constants.STEPS_PARAM] = int(self.get(constants.STEPS_PARAM, '0')) + 1
                     self.queueDispatch(FSM.PSEUDO_FINAL)
 
-        except HaltMachineError, e:
+        except HaltMachineError as e:
             if e.level is not None and e.message:
                 self.logger.log(e.level, e.message)
             return None # stop the machine
-        except Exception, e:
+        except Exception as e:
             level = self.logger.error
             if e.__class__ in TRANSIENT_ERRORS:
                 level = self.logger.warn
@@ -850,7 +850,7 @@ class FSMContext(dict):
         params = {constants.STATE_PARAM: state.name,
                   constants.EVENT_PARAM: event,
                   constants.INSTANCE_NAME_PARAM: self.instanceName}
-        for key, value in self.items():
+        for key, value in list(self.items()):
             if key not in constants.NON_CONTEXT_PARAMS:
                 if self.contextTypes.get(key) is json.loads:
                     value = json.dumps(value, cls=models.Encoder)
@@ -865,13 +865,13 @@ class FSMContext(dict):
                 valueIsNotBasestring = False
                 if isinstance(value, (list, tuple)):
                     for v in value:
-                        if not isinstance(v, basestring):
+                        if not isinstance(v, str):
                             valueIsNotBasestring = True
-                elif not isinstance(value, basestring):
+                elif not isinstance(value, str):
                     valueIsNotBasestring = True
 
                 if valueIsNotBasestring:
-                    if key not in self.contextTypes.keys():
+                    if key not in list(self.contextTypes.keys()):
                         self.logger.warning("Attempting to put an object in the FSMContext without specifying an "
                                             "entry for key '%s' in 'context_types' in the yaml for machineName '%s'. "
                                             "There will likely be conversion issues (ie. booleans turned into "
@@ -894,7 +894,7 @@ class FSMContext(dict):
         parts.append(instanceName or self.instanceName)
 
         if self.get(constants.GEN_PARAM):
-            for (step, gen) in self[constants.GEN_PARAM].items():
+            for (step, gen) in list(self[constants.GEN_PARAM].items()):
                 parts.append('continuation-%s-%s' % (step, gen))
         if self.get(constants.FORK_PARAM):
             parts.append('fork-' + str(self[constants.FORK_PARAM]))
@@ -959,7 +959,7 @@ def _queueTasks(Queue, queueName, tasks, transactional=False):
 
     # queue the Tasks in groups of MAX_TASKS_PER_ADD
     i = 0
-    for i in xrange(len(tasks)):
+    for i in range(len(tasks)):
         someTasks = tasks[i * MAX_TASKS_PER_ADD : (i+1) * MAX_TASKS_PER_ADD]
         if not someTasks:
             break
@@ -968,10 +968,10 @@ def _queueTasks(Queue, queueName, tasks, transactional=False):
         try:
             Queue(name=queueName).add(someTasks, transactional=transactional)
 
-        except TaskAlreadyExistsError, e:
+        except TaskAlreadyExistsError as e:
             taskAlreadyExists = e
 
-        except TombstonedTaskError, e:
+        except TombstonedTaskError as e:
             tombstonedTask = e
 
     if taskAlreadyExists:

--- a/src/fantasm/fsm.py
+++ b/src/fantasm/fsm.py
@@ -56,7 +56,7 @@ from fantasm import models
 from fantasm.utils import knuthHash
 from fantasm.lock import ReadWriteLock, RunOnceSemaphore
 
-class FSM(object):
+class FSM:
     """ An FSMContext creation factory. This is primarily responsible for translating machine
     configuration information (config.currentConfiguration()) into singleton States and Transitions as per [1]
     """
@@ -279,7 +279,7 @@ class FSMContext(dict):
         """
         assert queueName
 
-        super(FSMContext, self).__init__(data or {})
+        super().__init__(data or {})
         self.initialState = initialState
         self.currentState = currentState
         self.currentAction = None
@@ -317,7 +317,7 @@ class FSMContext(dict):
         dateStr = utcnow.strftime(self.INSTANCE_NAME_DTFORMAT)
         randomStr = ''.join(random.sample(constants.CHARS_FOR_RANDOM, 6))
         # note this construction is important for getInstanceStartTime()
-        return '%s-%s-%s' % (self.machineName, dateStr, randomStr)
+        return '{}-{}-{}'.format(self.machineName, dateStr, randomStr)
 
     def getInstanceStartTime(self):
         """ Returns the UTC datetime when the instance was started.
@@ -756,7 +756,7 @@ class FSMContext(dict):
             """ A list that supports .logger.info(), .logger.warning() etc.for fan-in actions """
             def __init__(self, context, contexts, guarded=False):
                 """ setup a self.logger for fan-in actions """
-                super(FSMContextList, self).__init__(contexts)
+                super().__init__(contexts)
                 self.logger = Logger(context)
                 self.instanceName = context.instanceName
                 self.guarded = guarded
@@ -835,7 +835,7 @@ class FSMContext(dict):
         @return: a url that can be used to build a taskqueue.Task instance to .dispatch(event)
         """
         assert state and event
-        return self.url + '%s/%s/%s/' % (state.name,
+        return self.url + '{}/{}/{}/'.format(state.name,
                                          event,
                                          state.getTransition(event).target.name)
 
@@ -895,7 +895,7 @@ class FSMContext(dict):
 
         if self.get(constants.GEN_PARAM):
             for (step, gen) in list(self[constants.GEN_PARAM].items()):
-                parts.append('continuation-%s-%s' % (step, gen))
+                parts.append('continuation-{}-{}'.format(step, gen))
         if self.get(constants.FORK_PARAM):
             parts.append('fork-' + str(self[constants.FORK_PARAM]))
         # post-fan-in we need to store the workIndex in the task name to avoid duplicates, since

--- a/src/fantasm/handlers.py
+++ b/src/fantasm/handlers.py
@@ -219,14 +219,14 @@ class FSMHandler(webapp.RequestHandler):
 
         # the case of headers is inconsistent on dev_appserver and appengine
         # ie 'X-AppEngine-TaskRetryCount' vs. 'X-AppEngine-Taskretrycount'
-        lowerCaseHeaders = dict([(key.lower(), value) for key, value in self.request.headers.items()])
+        lowerCaseHeaders = dict([(key.lower(), value) for key, value in list(self.request.headers.items())])
 
         taskName = lowerCaseHeaders.get('x-appengine-taskname')
         retryCount = int(lowerCaseHeaders.get('x-appengine-taskretrycount', 0))
 
         # pull out X-Fantasm-* headers
         headers = None
-        for key, value in self.request.headers.items():
+        for key, value in list(self.request.headers.items()):
             if key.startswith(HTTP_REQUEST_HEADER_PREFIX):
                 headers = headers or {}
                 if ',' in value:
@@ -274,7 +274,7 @@ class FSMHandler(webapp.RequestHandler):
 
         # in "immediate mode" we try to execute as much as possible in the current request
         # for the time being, this does not include things like fork/spawn/contuniuations/fan-in
-        immediateMode = IMMEDIATE_MODE_PARAM in requestData.keys()
+        immediateMode = IMMEDIATE_MODE_PARAM in list(requestData.keys())
         if immediateMode:
             obj[IMMEDIATE_MODE_PARAM] = immediateMode
             obj[MESSAGES_PARAM] = []
@@ -285,7 +285,7 @@ class FSMHandler(webapp.RequestHandler):
         self.fsm = fsm # used for logging in handle_exception
 
         # pull all the data off the url and stuff into the context
-        for key, value in requestData.items():
+        for key, value in list(requestData.items()):
             if key in NON_CONTEXT_PARAMS:
                 continue # these are special, don't put them in the data
 
@@ -299,7 +299,7 @@ class FSMHandler(webapp.RequestHandler):
                 key = key[:-2]
                 value = [value]
 
-            if key in fsm.contextTypes.keys():
+            if key in list(fsm.contextTypes.keys()):
                 fsm.putTypedValue(key, value)
             else:
                 fsm[key] = value

--- a/src/fantasm/handlers.py
+++ b/src/fantasm/handlers.py
@@ -17,32 +17,33 @@ Copyright 2010 VendAsta Technologies Inc.
    limitations under the License.
 """
 
-import time
+import json
 import logging
 import sys
+import time
 import traceback
 
-if sys.version_info < (2, 7):
-    import simplejson as json
-else:
-    import json
+from google.appengine.ext import db, deferred, webapp
 
-from google.appengine.ext import deferred, webapp, db
 try:
     from google.appengine.api.capabilities import CapabilitySet
 except ImportError:
     CapabilitySet = None
 from google.appengine.ext import ndb
+
 from fantasm import config, constants
+from fantasm.constants import (EVENT_PARAM, HTTP_REQUEST_HEADER_PREFIX,
+                               IMMEDIATE_MODE_PARAM, INSTANCE_NAME_PARAM,
+                               MESSAGES_PARAM, NON_CONTEXT_PARAMS,
+                               RETRY_COUNT_PARAM, STARTED_AT_PARAM,
+                               STATE_PARAM, TASK_NAME_PARAM)
+from fantasm.exceptions import (TRANSIENT_ERRORS, FSMRuntimeError,
+                                RequiredServicesUnavailableRuntimeError,
+                                UnknownMachineError)
 from fantasm.fsm import FSM
-from fantasm.utils import NoOpQueue
-from fantasm.constants import NON_CONTEXT_PARAMS, STATE_PARAM, EVENT_PARAM, INSTANCE_NAME_PARAM, TASK_NAME_PARAM, \
-                              RETRY_COUNT_PARAM, STARTED_AT_PARAM, IMMEDIATE_MODE_PARAM, MESSAGES_PARAM, \
-                              HTTP_REQUEST_HEADER_PREFIX
-from fantasm.exceptions import UnknownMachineError, RequiredServicesUnavailableRuntimeError, FSMRuntimeError, \
-                               TRANSIENT_ERRORS
-from fantasm.models import Encoder, _FantasmFanIn
 from fantasm.lock import RunOnceSemaphore
+from fantasm.models import Encoder, _FantasmFanIn
+from fantasm.utils import NoOpQueue
 
 REQUIRED_SERVICES = ('memcache', 'datastore_v3', 'taskqueue')
 

--- a/src/fantasm/handlers.py
+++ b/src/fantasm/handlers.py
@@ -128,19 +128,19 @@ class FSMGraphvizHandler(webapp.RequestHandler):
 <head></head>
 <body onload="javascript:document.forms.chartform.submit();">
 <form id='chartform' action='http://chart.apis.google.com/chart' method='POST'>
-  <input type="hidden" name="cht" value="gv:%(cht)s"  />
-  <input type="hidden" name="chs" value="%(chs)s"  />
-  <input type="hidden" name="chl" value='%(chl)s'  />
-  <input type="hidden" name="chd" value="%(chd)s"  />
-  <input type="hidden" name="chof" value="%(chof)s"  />
-  <input type="submit" value="Generate GraphViz .%(chof)s" />
+  <input type="hidden" name="cht" value="gv:{cht}"  />
+  <input type="hidden" name="chs" value="{chs}"  />
+  <input type="hidden" name="chl" value='{chl}'  />
+  <input type="hidden" name="chd" value="{chd}"  />
+  <input type="hidden" name="chof" value="{chof}"  />
+  <input type="submit" value="Generate GraphViz .{chof}" />
 </form>
 </body>
-""" % {'cht': cht,
-       'chs': chs,
-       'chl': chl,
-       'chd': chd,
-       'chof': chof})
+""".format(cht=cht,
+       chs=chs,
+       chl=chl,
+       chd=chd,
+       chof=chof))
 
         else:
             self.response.out.write(content)
@@ -175,7 +175,7 @@ class FSMHandler(webapp.RequestHandler):
 
     def initialize(self, request, response):
         """Initializes this request handler with the given Request and Response."""
-        super(FSMHandler, self).initialize(request, response)
+        super().initialize(request, response)
         # pylint: disable=W0201
         # - this is the preferred location to initialize the handler in the webapp framework
         self.fsm = None
@@ -219,7 +219,7 @@ class FSMHandler(webapp.RequestHandler):
 
         # the case of headers is inconsistent on dev_appserver and appengine
         # ie 'X-AppEngine-TaskRetryCount' vs. 'X-AppEngine-Taskretrycount'
-        lowerCaseHeaders = dict([(key.lower(), value) for key, value in list(self.request.headers.items())])
+        lowerCaseHeaders = {key.lower(): value for key, value in list(self.request.headers.items())}
 
         taskName = lowerCaseHeaders.get('x-appengine-taskname')
         retryCount = int(lowerCaseHeaders.get('x-appengine-taskretrycount', 0))
@@ -264,7 +264,7 @@ class FSMHandler(webapp.RequestHandler):
         # Taskqueue can invoke multiple tasks of the same name occassionally. Here, we'll use
         # a datastore transaction as a semaphore to determine if we should actually execute this or not.
         if taskName and fsm.useRunOnceSemaphore:
-            semaphoreKey = '%s--%s' % (taskName, retryCount)
+            semaphoreKey = '{}--{}'.format(taskName, retryCount)
             semaphore = RunOnceSemaphore(semaphoreKey, None)
             if not semaphore.writeRunOnceSemaphore(payload='fantasm')[0]:
                 # we can simply return here, this is a duplicate fired task

--- a/src/fantasm/lock.py
+++ b/src/fantasm/lock.py
@@ -29,7 +29,7 @@ from fantasm.exceptions import FanInReadLockFailureRuntimeError
 
 # a variety of locking mechanisms to enforce idempotency (of the framework) in the face of retries
 
-class ReadWriteLock( object ):
+class ReadWriteLock:
     """ A read/write lock that allows
 
     1. non-blocking write (for speed of fan-out)
@@ -147,7 +147,7 @@ class ReadWriteLock( object ):
 
         return acquired
 
-class RunOnceSemaphore( object ):
+class RunOnceSemaphore:
     """ A object used to enforce run-once semantics """
 
     def __init__(self, semaphoreKey, context, obj=None):

--- a/src/fantasm/lock.py
+++ b/src/fantasm/lock.py
@@ -125,7 +125,7 @@ class ReadWriteLock( object ):
         memcache.decr(lockKey, 2**15, namespace=None)
 
         # busy wait for writers
-        for i in xrange(ReadWriteLock.BUSY_WAIT_ITERS):
+        for i in range(ReadWriteLock.BUSY_WAIT_ITERS):
             counter = memcache.get(lockKey, namespace=None)
             # counter is None --> ejected from memcache, or no writers
             # int(counter) <= 2**15 --> writers have all called memcache.decr

--- a/src/fantasm/log.py
+++ b/src/fantasm/log.py
@@ -20,7 +20,7 @@ Copyright 2010 VendAsta Technologies Inc.
 import logging
 import datetime
 import traceback
-import StringIO
+import io
 import random
 from google.appengine.ext import deferred, db
 from fantasm.models import _FantasmLog
@@ -131,14 +131,14 @@ class Logger( object ):
 
         stack = None
         if 'exc_info' in kwargs:
-            f = StringIO.StringIO()
+            f = io.StringIO()
             traceback.print_exc(25, f)
             stack = f.getvalue()
 
         # this _log method requires everything to be serializable, which is not the case for the logging
         # module. if message is not a basestring, then we simply cast it to a string to allow _something_
         # to be logged in the deferred task
-        if not isinstance(message, basestring):
+        if not isinstance(message, str):
             try:
                 message = str(message)
             except Exception:

--- a/src/fantasm/log.py
+++ b/src/fantasm/log.py
@@ -62,7 +62,7 @@ def _log(taskName,
         pass
 
     randomStr = ''.join(random.sample(constants.CHARS_FOR_RANDOM, 8))
-    keyName = '%s:%s' % (taskName, randomStr)
+    keyName = '{}:{}'.format(taskName, randomStr)
     key = db.Key.from_path(_FantasmLog.kind(), keyName, namespace='')
     _FantasmLog(key=key,
                 taskName=taskName,
@@ -78,7 +78,7 @@ def _log(taskName,
                 stack=stack,
                 time=time).put()
 
-class Logger( object ):
+class Logger:
     """ A object that allows an FSMContext to have methods debug, info etc. similar to logging.debug/info etc. """
 
     _LOGGING_MAP = {

--- a/src/fantasm/models.py
+++ b/src/fantasm/models.py
@@ -83,7 +83,7 @@ class JSONProperty(db.Property):
 
     def get_value_for_datastore(self, modelInstance):
         """ see Property.get_value_for_datastore """
-        value = super(JSONProperty, self).get_value_for_datastore(modelInstance)
+        value = super().get_value_for_datastore(modelInstance)
         return db.Text(self._deflate(value))
 
     def validate(self, value):

--- a/src/fantasm/models.py
+++ b/src/fantasm/models.py
@@ -98,7 +98,7 @@ class JSONProperty(db.Property):
         """ decodes string -> dict """
         if value is None:
             return {}
-        if isinstance(value, unicode) or isinstance(value, str):
+        if isinstance(value, str) or isinstance(value, str):
             return json.loads(value, object_hook=decode)
         return value
 

--- a/src/fantasm/models.py
+++ b/src/fantasm/models.py
@@ -17,16 +17,11 @@ Copyright 2010 VendAsta Technologies Inc.
    limitations under the License.
 """
 
-from google.appengine.ext import db, ndb
-from google.appengine.api import datastore_types
-
 import datetime
-import sys
+import json
 
-if sys.version_info < (2, 7):
-    import simplejson as json
-else:
-    import json
+from google.appengine.api import datastore_types
+from google.appengine.ext import db, ndb
 
 
 def decode(dct):

--- a/src/fantasm/scrubber.py
+++ b/src/fantasm/scrubber.py
@@ -29,7 +29,7 @@ from fantasm.constants import CONTINUATION_RESULTS_KEY
 # implementing interfaces
 # pylint: disable=W0613
 
-class InitalizeScrubber(object):
+class InitalizeScrubber:
     """ Use current time to set up task names. """
     def execute(self, context, obj):
         """ Computes the before date and adds to context. """
@@ -37,7 +37,7 @@ class InitalizeScrubber(object):
         context['before'] = datetime.datetime.utcnow() - datetime.timedelta(days=age)
         return 'next'
 
-class EnumerateFantasmModels(object):
+class EnumerateFantasmModels:
     """ Kick off a continuation for each model. """
 
     FANTASM_MODELS = (

--- a/src/fantasm/state.py
+++ b/src/fantasm/state.py
@@ -68,7 +68,7 @@ class State(object):
         @param event: a string event that results in the associated Transition to execute
         """
         assert isinstance(transition, Transition)
-        assert isinstance(event, basestring)
+        assert isinstance(event, str)
 
         assert not (self.exitAction and transition.target.isContinuation) # TODO: revisit this with jcollins
         assert not (self.exitAction and transition.target.isFanIn) # TODO: revisit
@@ -106,7 +106,7 @@ class State(object):
                 context.currentState.exitAction.execute(context, obj)
             except HaltMachineError:
                 raise # let it bubble up quietly
-            except Exception, e:
+            except Exception as e:
                 level = context.logger.error
                 if e.__class__ in TRANSIENT_ERRORS:
                     level = context.logger.warn
@@ -136,7 +136,7 @@ class State(object):
                 context.currentState.entryAction.execute(contextOrContexts, obj)
             except HaltMachineError:
                 raise # let it bubble up quietly
-            except Exception, e:
+            except Exception as e:
                 level = context.logger.error
                 if e.__class__ in TRANSIENT_ERRORS:
                     level = context.logger.warn
@@ -153,7 +153,7 @@ class State(object):
                 context.pop(constants.CONTINUATION_PARAM, None) # pop this off because it is really long
             except HaltMachineError:
                 raise # let it bubble up quietly
-            except Exception, e:
+            except Exception as e:
                 level = context.logger.error
                 if e.__class__ in TRANSIENT_ERRORS:
                     level = context.logger.warn
@@ -172,7 +172,7 @@ class State(object):
                 nextEvent = context.currentState.doAction.execute(contextOrContexts, obj)
             except HaltMachineError:
                 raise # let it bubble up quietly
-            except Exception, e:
+            except Exception as e:
                 level = context.logger.error
                 if e.__class__ in TRANSIENT_ERRORS:
                     level = context.logger.warn

--- a/src/fantasm/state.py
+++ b/src/fantasm/state.py
@@ -25,7 +25,7 @@ from fantasm.exceptions import UnknownEventError, InvalidEventNameRuntimeError, 
 from fantasm.utils import knuthHash
 from fantasm.lock import RunOnceSemaphore
 
-class State(object):
+class State:
     """ A state object for a machine. """
 
     def __init__(self, name, entryAction, doAction, exitAction, machineName=None,

--- a/src/fantasm/transition.py
+++ b/src/fantasm/transition.py
@@ -18,7 +18,7 @@ Copyright 2010 VendAsta Technologies Inc.
 """
 from fantasm.exceptions import TRANSIENT_ERRORS, HaltMachineError
 
-class Transition(object):
+class Transition:
     """ A transition object for a machine. """
 
     def __init__(self, name, target, action=None, countdown=0, retryOptions=None, queueName=None, taskTarget=None):

--- a/src/fantasm/transition.py
+++ b/src/fantasm/transition.py
@@ -55,7 +55,7 @@ class Transition(object):
                 self.action.execute(context, obj)
             except HaltMachineError:
                 raise # let it bubble up quietly
-            except Exception, e:
+            except Exception as e:
                 level = context.logger.error
                 if e.__class__ in TRANSIENT_ERRORS:
                     level = context.logger.warn

--- a/src/fantasm/utils.py
+++ b/src/fantasm/utils.py
@@ -103,7 +103,7 @@ def outputMachineConfig(machineConfig, colorMap=None, skipStateNames=None):
     lines.append('labelloc="t"')
     lines.append('"__start__" [label="start",shape=circle,style=filled,fillcolor=black,fontcolor=white,fontsize=9];')
     lines.append('"__end__" [label="end",shape=doublecircle,style=filled,fillcolor=black,fontcolor=white,fontsize=9];')
-    for stateConfig in machineConfig.states.values():
+    for stateConfig in list(machineConfig.states.values()):
         if stateConfig.name in skipStateNames:
             continue
         lines.append(outputStateConfig(stateConfig, colorMap=colorMap))
@@ -111,7 +111,7 @@ def outputMachineConfig(machineConfig, colorMap=None, skipStateNames=None):
             lines.append('"__start__" -> "%(stateName)s"' % {'stateName': stateConfig.name})
         if stateConfig.final:
             lines.append('"%(stateName)s" -> "__end__"' % {'stateName': stateConfig.name})
-    for transitionConfig in machineConfig.transitions.values():
+    for transitionConfig in list(machineConfig.transitions.values()):
         if transitionConfig.fromState.name in skipStateNames or \
            transitionConfig.toState.name in skipStateNames:
             continue

--- a/src/fantasm/utils.py
+++ b/src/fantasm/utils.py
@@ -65,18 +65,18 @@ def outputStateConfig(stateConfig, colorMap=None):
     colorMap = colorMap or {}
     actions = []
     if stateConfig.entry:
-        actions.append('entry/ %(entry)s' % {'entry': outputAction(stateConfig.entry)})
+        actions.append('entry/ {entry}'.format(entry=outputAction(stateConfig.entry)))
     if stateConfig.action:
-        actions.append('do/ %(do)s' % {'do': outputAction(stateConfig.action)})
+        actions.append('do/ {do}'.format(do=outputAction(stateConfig.action)))
     if stateConfig.exit:
-        actions.append('exit/ %(exit)s' % {'exit': outputAction(stateConfig.exit)})
-    label = '%(stateName)s|%(actions)s' % {'stateName': stateConfig.name, 'actions': '\\l'.join(actions)}
+        actions.append('exit/ {exit}'.format(exit=outputAction(stateConfig.exit)))
+    label = '{stateName}|{actions}'.format(stateName=stateConfig.name, actions='\\l'.join(actions))
     if stateConfig.continuation:
         label += '|continuation = True'
     if stateConfig.fanInPeriod != constants.NO_FAN_IN:
         label += '|fan in period = %(fanin)ds' % {'fanin': stateConfig.fanInPeriod}
     if stateConfig.fanInGroup:
-        label += '|fan in group = %(faningroup)s' % {'faningroup': stateConfig.fanInGroup}
+        label += '|fan in group = {faningroup}'.format(faningroup=stateConfig.fanInGroup)
     shape = 'Mrecord'
     if colorMap.get(stateConfig.name):
         return '"%(stateName)s" [style=filled,fillcolor="%(fillcolor)s",shape=%(shape)s,label="{%(label)s}"];' % \
@@ -99,7 +99,7 @@ def outputMachineConfig(machineConfig, colorMap=None, skipStateNames=None):
     skipStateNames = skipStateNames or ()
     lines = []
     lines.append('digraph G {')
-    lines.append('label="%(machineName)s"' % {'machineName': machineConfig.name})
+    lines.append('label="{machineName}"'.format(machineName=machineConfig.name))
     lines.append('labelloc="t"')
     lines.append('"__start__" [label="start",shape=circle,style=filled,fillcolor=black,fontcolor=white,fontsize=9];')
     lines.append('"__end__" [label="end",shape=doublecircle,style=filled,fillcolor=black,fontcolor=white,fontsize=9];')
@@ -108,13 +108,13 @@ def outputMachineConfig(machineConfig, colorMap=None, skipStateNames=None):
             continue
         lines.append(outputStateConfig(stateConfig, colorMap=colorMap))
         if stateConfig.initial:
-            lines.append('"__start__" -> "%(stateName)s"' % {'stateName': stateConfig.name})
+            lines.append('"__start__" -> "{stateName}"'.format(stateName=stateConfig.name))
         if stateConfig.final:
-            lines.append('"%(stateName)s" -> "__end__"' % {'stateName': stateConfig.name})
+            lines.append('"{stateName}" -> "__end__"'.format(stateName=stateConfig.name))
     for transitionConfig in list(machineConfig.transitions.values()):
         if transitionConfig.fromState.name in skipStateNames or \
            transitionConfig.toState.name in skipStateNames:
             continue
         lines.append(outputTransitionConfig(transitionConfig))
     lines.append('}')
-    return '\n'.join(lines) 
+    return '\n'.join(lines)

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="fantasm",
     version="2.0.0",
-    packages=find_packages(where="src/fantasm"),
+    packages=find_packages(),
     url="http://github.com/vendasta/fantasm",
     install_requires=[
         "appengine-python-standard==1.1.5",

--- a/src/setup.py
+++ b/src/setup.py
@@ -9,4 +9,7 @@ setup(
         "appengine-python-standard==1.1.5",
         "PyYAML==6.0.1",
     ],
+    package_data={
+        'fantasm': ['scrubber.yaml'],
+    },
 )

--- a/test/appengine_config.py
+++ b/test/appengine_config.py
@@ -6,10 +6,10 @@ FIXME: work in progress, currently disabled
 import random
 import google.appengine.ext.db
 
-from fantasm.models import _FantasmFanIn
-from fantasm.models import _FantasmTaskSemaphore
-from fantasm.models import _FantasmInstance
-from fantasm.models import _FantasmLog
+from .fantasm.models import _FantasmFanIn
+from .fantasm.models import _FantasmTaskSemaphore
+from .fantasm.models import _FantasmInstance
+from .fantasm.models import _FantasmLog
 
 GET = google.appengine.ext.db.get
 GET_THRESHOLD = 0.1

--- a/test/appengine_config.py
+++ b/test/appengine_config.py
@@ -69,8 +69,7 @@ def exceptionGeneratingWsgiMiddleware(app):
             restore()
             raise
         if result is not None:
-            for value in result:
-                yield value
+            yield from result
         restore()
     return exceptionGeneratingWsgiWrapper
 

--- a/test/appengine_console.py
+++ b/test/appengine_console.py
@@ -13,7 +13,7 @@ def auth_func():
     return input('Username:'), getpass.getpass('Password:')
 
 if len(sys.argv) < 2:
-    print("Usage: %s app_id [host]" % (sys.argv[0],))
+    print("Usage: {} app_id [host]".format(sys.argv[0]))
 app_id = sys.argv[1]
 if len(sys.argv) > 2:
     host = sys.argv[2]
@@ -22,4 +22,4 @@ else:
 
 remote_api_stub.ConfigureRemoteDatastore(app_id, '/remote_api', auth_func, host)
 
-code.interact('App Engine interactive console for %s' % (app_id,), None, locals())
+code.interact('App Engine interactive console for {}'.format(app_id), None, locals())

--- a/test/appengine_console.py
+++ b/test/appengine_console.py
@@ -10,10 +10,10 @@ from google.appengine.ext.remote_api import remote_api_stub
 from google.appengine.ext import db
 
 def auth_func():
-    return raw_input('Username:'), getpass.getpass('Password:')
+    return input('Username:'), getpass.getpass('Password:')
 
 if len(sys.argv) < 2:
-    print "Usage: %s app_id [host]" % (sys.argv[0],)
+    print("Usage: %s app_id [host]" % (sys.argv[0],))
 app_id = sys.argv[1]
 if len(sys.argv) > 2:
     host = sys.argv[2]

--- a/test/backup.py
+++ b/test/backup.py
@@ -7,8 +7,8 @@ from google.appengine.ext import db
 from google.appengine.ext import blobstore
 from google.appengine.ext import webapp
 from google.appengine.api import memcache
-from fantasm.action import FSMAction, DatastoreContinuationFSMAction
-from fantasm.constants import CONTINUATION_RESULT_KEY
+from .fantasm.action import FSMAction, DatastoreContinuationFSMAction
+from .fantasm.constants import CONTINUATION_RESULT_KEY
 
 FULL_BACKUP_ON_DAY_OF_WEEK = 2 # 0 = Monday, 1 = Tuesday, 2 = Wednesday, ...
 DELETE_BACKUPS_OLDER_THAN_DAYS = 90 # set to -1 to disable
@@ -155,7 +155,7 @@ class BackupEntity(DatastoreContinuationFSMAction):
 
             # copy over the property values
             kwargs = {}
-            for prop in originalEntity.properties().values():
+            for prop in list(originalEntity.properties().values()):
                 if isinstance(prop, (db.ReferenceProperty, blobstore.BlobReferenceProperty)):
                     # avoid the dereference/auto-lookup
                     datastoreValue = prop.get_value_for_datastore(originalEntity)

--- a/test/backup.py
+++ b/test/backup.py
@@ -46,9 +46,9 @@ BACKUP_CONFIG = (
     (Company,                         'modifiedDate',     10),
     # add more models here
 )
-BACKUP_CLASS = dict( (m[0].__name__, m[0]) for m in BACKUP_CONFIG )
-BACKUP_INCREMENTAL_PROPERTY = dict( (m[0].__name__, m[1]) for m in BACKUP_CONFIG )
-BACKUP_BATCH_SIZE = dict( (m[0].__name__, m[2]) for m in BACKUP_CONFIG )
+BACKUP_CLASS = { m[0].__name__: m[0] for m in BACKUP_CONFIG }
+BACKUP_INCREMENTAL_PROPERTY = { m[0].__name__: m[1] for m in BACKUP_CONFIG }
+BACKUP_BATCH_SIZE = { m[0].__name__: m[2] for m in BACKUP_CONFIG }
 BACKUP_MODELS = sorted(BACKUP_CLASS.keys())
 
 
@@ -99,7 +99,7 @@ class EnumerateBackupModels(FSMAction):
         
         def tx():
             """ Gets the backup meta information for this model, creating if necessary. """
-            keyName = '%s:%s' % (backupId, model)
+            keyName = '{}:{}'.format(backupId, model)
             entry = _Backup.get_by_key_name(keyName)
             
             if not entry:

--- a/test/complex_machine.py
+++ b/test/complex_machine.py
@@ -4,8 +4,8 @@ import random
 import time
 import os
 import pickle
-from fantasm.action import FSMAction, DatastoreContinuationFSMAction
-from fantasm.constants import CONTINUATION_RESULTS_KEY
+from .fantasm.action import FSMAction, DatastoreContinuationFSMAction
+from .fantasm.constants import CONTINUATION_RESULTS_KEY
 from google.appengine.ext import db
 
 # pylint: disable=C0111
@@ -35,7 +35,7 @@ class MyDatastoreContinuationFSMAction(DatastoreContinuationFSMAction):
 class EntryAction1(FSMAction):
     def execute(self, context, obj):
         context['foo'] = 'bar'
-        context['unicode'] = u'\xe8'
+        context['unicode'] = '\xe8'
         if 'failure' in context  and random.random() < 0.25:
             raise Exception('failure')
 

--- a/test/csv_report_generation.py
+++ b/test/csv_report_generation.py
@@ -1,24 +1,24 @@
 """ Code for the csv report generation example. """
-from __future__ import with_statement
+
 
 import csv
 import pickle
 import logging
 
-from fantasm.action import FSMAction
-from fantasm.action import ContinuationFSMAction
-from fantasm.action import DatastoreContinuationFSMAction
-from fantasm.constants import CONTINUATION_RESULTS_KEY
-from fantasm.constants import CONTINUATION_RESULTS_COUNTER_PARAM
-from fantasm.constants import CONTINUATION_COMPLETE_PARAM
-from fantasm.constants import TASK_NAME_PARAM
-from fantasm.constants import STEPS_PARAM
-from fantasm.lock import RunOnceSemaphore
+from .fantasm.action import FSMAction
+from .fantasm.action import ContinuationFSMAction
+from .fantasm.action import DatastoreContinuationFSMAction
+from .fantasm.constants import CONTINUATION_RESULTS_KEY
+from .fantasm.constants import CONTINUATION_RESULTS_COUNTER_PARAM
+from .fantasm.constants import CONTINUATION_COMPLETE_PARAM
+from .fantasm.constants import TASK_NAME_PARAM
+from .fantasm.constants import STEPS_PARAM
+from .fantasm.lock import RunOnceSemaphore
 
 from google.appengine.ext import db
 from google.appengine.api import files
 
-from complex_machine import TestModel
+from .complex_machine import TestModel
 
 OK_EVENT = 'ok'
 
@@ -292,7 +292,7 @@ class ReadInputRecords( CsvContinuation ):
     
     def generateAggregatedCsvData(self, context, obj, entities):
         """ Return the sum of the prop1 field (guids cast to ints)"""
-        return sum([long(e.prop1.replace('-', ''), 16) for e in entities])
+        return sum([int(e.prop1.replace('-', ''), 16) for e in entities])
     
 class WriteIntermediateRecords( CsvFanIn ):
     

--- a/test/email_batch.py
+++ b/test/email_batch.py
@@ -13,7 +13,7 @@ from .fantasm.constants import CONTINUATION_RESULT_KEY
 VALIDATION_COUNTDOWN = 4*60*60
 BATCH_SUCCESS_RATE = 0.95
 
-class StartBatch(object):
+class StartBatch:
 
     def execute(self, context, obj):
 
@@ -50,7 +50,7 @@ class SendEmail(DatastoreContinuationFSMAction):
 
         return 'next'
 
-class UpdateCounter(object):
+class UpdateCounter:
 
     def execute(self, contexts, obj): # contexts (plural) because this is a fan_in
 
@@ -66,7 +66,7 @@ class UpdateCounter(object):
 
         db.run_in_transaction(txn)
 
-class ValidateBatch(object):
+class ValidateBatch:
 
     def execute(self, context, obj):
 

--- a/test/email_batch.py
+++ b/test/email_batch.py
@@ -3,8 +3,8 @@ import logging
 from datetime import datetime
 from google.appengine.ext import db
 from google.appengine.ext import webapp
-from fantasm.action import DatastoreContinuationFSMAction
-from fantasm.constants import CONTINUATION_RESULT_KEY
+from .fantasm.action import DatastoreContinuationFSMAction
+from .fantasm.constants import CONTINUATION_RESULT_KEY
 
 # pylint: disable=C0111, W0613, C0103
 # - docstring not reqd

--- a/test/fantasm_tests/__init__.py
+++ b/test/fantasm_tests/__init__.py
@@ -4,12 +4,12 @@
 # - docstrings not reqd in unit tests
 
 # The following three classes are here to test namespace overriding.
-class MockAction2(object):
+class MockAction2:
     def execute(self, context, obj):
         pass
-class MockEntry2(object):
+class MockEntry2:
     def execute(self, context, obj):
         pass
-class MockExit2(object):
+class MockExit2:
     def execute(self, context, obj):
         pass

--- a/test/fantasm_tests/actions.py
+++ b/test/fantasm_tests/actions.py
@@ -13,7 +13,7 @@ from fantasm.exceptions import HaltMachineError
 # - docstrings not reqd in unit tests
 # - these actions do not use arguments
 
-class Custom(object):
+class Custom:
     def __init__(self, string):
         self.impl = eval(string)
     def __repr__(self):
@@ -24,7 +24,7 @@ class CustomImpl(Custom):
         self.a = a
         self.b = b
     def __repr__(self):
-        return 'CustomImpl(a="%s", b="%s")' % (self.a, self.b)
+        return 'CustomImpl(a="{}", b="{}")'.format(self.a, self.b)
     def __eq__(self, other):
         # just for unit test equality
         if other.__class__ is Custom:
@@ -36,12 +36,12 @@ class CustomImpl(Custom):
             other = other.impl
         return self.a != other.a or self.b != other.b
 
-class ContextRecorder(object):
+class ContextRecorder:
     CONTEXTS = []
     def execute(self, context, obj):
         self.CONTEXTS.append(context)
 
-class CountExecuteCalls(object):
+class CountExecuteCalls:
     def __init__(self):
         self.count = 0
         self.fails = 0
@@ -58,10 +58,10 @@ class CountExecuteCalls(object):
 class CountExecuteCallsWithSpawn(CountExecuteCalls):
     def execute(self, context, obj):
         context.spawn('MachineToSpawn', [{'a': '1'}, {'b': '2'}])
-        super(CountExecuteCallsWithSpawn, self).execute(context, obj)
+        super().execute(context, obj)
         return None
 
-class CountExecuteCallsWithFork(object):
+class CountExecuteCallsWithFork:
     def __init__(self):
         self.count = 0
         self.fails = 0
@@ -78,7 +78,7 @@ class CountExecuteCallsWithFork(object):
     def event(self):
         return 'next-event'
 
-class CountExecuteAndContinuationCalls(object):
+class CountExecuteAndContinuationCalls:
     def __init__(self):
         self.count = 0
         self.ccount = 0
@@ -102,7 +102,7 @@ class CountExecuteAndContinuationCalls(object):
     def event(self):
         return 'next-event'
 
-class CountExecuteCallsFanInEntry(object):
+class CountExecuteCallsFanInEntry:
     def __init__(self):
         self.count = 0
         self.fcount = 0
@@ -132,7 +132,7 @@ class CountExecuteCallsFanIn(CountExecuteCallsFanInEntry):
             result = ResultModel(total=0, key_name=context.instanceName)
         result.total += sum([len(c.get('fan-me-in', [])) for c in context])
         result.put() # txn is overkill for this test
-        return super(CountExecuteCallsFanIn, self).execute(context, obj)
+        return super().execute(context, obj)
     @property
     def event(self):
         return 'next-event'
@@ -147,7 +147,7 @@ class CountExecuteCallsFinal(CountExecuteCalls):
     def event(self):
         return None
 
-class CountExecuteCallsSelfTransition(object):
+class CountExecuteCallsSelfTransition:
     def __init__(self):
         self.count = 0
         self.fails = 0
@@ -161,25 +161,25 @@ class CountExecuteCallsSelfTransition(object):
         else:
             return 'next-event2'
 
-class RaiseExceptionAction(object):
+class RaiseExceptionAction:
     def execute(self, context, obj):
         raise Exception('instrumented exception')
 
-class RaiseExceptionContinuationAction(object):
+class RaiseExceptionContinuationAction:
     def continuation(self, context, obj, token=None):
         return "token"
     def execute(self, context, obj):
         raise Exception('instrumented exception')
 
-class RaiseHaltMachineErrorAction(object):
+class RaiseHaltMachineErrorAction:
     def execute(self, context, obj):
         raise HaltMachineError('instrumented exception', logLevel=logging.DEBUG)
 
-class RaiseHaltMachineErrorActionNoMessage(object):
+class RaiseHaltMachineErrorActionNoMessage:
     def execute(self, context, obj):
         raise HaltMachineError('instrumented exception', logLevel=None) # do not log
 
-class RaiseHaltMachineErrorContinuationAction(object):
+class RaiseHaltMachineErrorContinuationAction:
     def continuation(self, context, obj, token=None):
         raise HaltMachineError('instrumented exception', logLevel=logging.DEBUG)
     def execute(self, context, obj):
@@ -187,7 +187,7 @@ class RaiseHaltMachineErrorContinuationAction(object):
 
 class TestDatastoreContinuationFSMAction(DatastoreContinuationFSMAction):
     def __init__(self):
-        super(TestDatastoreContinuationFSMAction, self).__init__()
+        super().__init__()
         self.count = 0
         self.ccount = 0
         self.fails = 0
@@ -201,7 +201,7 @@ class TestDatastoreContinuationFSMAction(DatastoreContinuationFSMAction):
         self.ccount += 1
         if self.ccount == self.cfailat:
             raise Exception()
-        return super(TestDatastoreContinuationFSMAction, self).continuation(context, obj, token=token)
+        return super().continuation(context, obj, token=token)
     def execute(self, context, obj):
         if not obj[CONTINUATION_RESULTS_KEY]:
             return None
@@ -219,7 +219,7 @@ class TestDatastoreContinuationFSMActionFanInGroupFSMAction(TestDatastoreContinu
     def execute(self, context, obj):
         if CONTINUATION_RESULTS_KEY in obj and obj[CONTINUATION_RESULTS_KEY]:
             context['fan-in-group'] = obj[CONTINUATION_RESULTS_KEY][0].key().id_or_name()
-        return super(TestDatastoreContinuationFSMActionFanInGroupFSMAction, self).execute(context, obj)
+        return super().execute(context, obj)
 
 class HappySadContinuationFSMAction(TestDatastoreContinuationFSMAction):
     def execute(self, context, obj):
@@ -240,7 +240,7 @@ class TestFileContinuationFSMAction(ContinuationFSMAction):
     CONTEXTS = []
     ENTRIES = ['a', 'b', 'c', 'd']
     def __init__(self):
-        super(TestFileContinuationFSMAction, self).__init__()
+        super().__init__()
         self.count = 0
         self.ccount = 0
         self.fails = 0
@@ -269,7 +269,7 @@ class TestFileContinuationFSMAction(ContinuationFSMAction):
 
 class TestContinuationAndForkFSMAction(DatastoreContinuationFSMAction):
     def __init__(self):
-        super(TestContinuationAndForkFSMAction, self).__init__()
+        super().__init__()
         self.count = 0
         self.ccount = 0
         self.fails = 0
@@ -283,7 +283,7 @@ class TestContinuationAndForkFSMAction(DatastoreContinuationFSMAction):
         self.ccount += 1
         if self.ccount == self.cfailat:
             raise Exception()
-        return super(TestContinuationAndForkFSMAction, self).continuation(context, obj, token=token)
+        return super().continuation(context, obj, token=token)
     def execute(self, context, obj):
         if not obj[CONTINUATION_RESULTS_KEY]:
             return None
@@ -315,7 +315,7 @@ class DoubleContinuation1(ContinuationFSMAction):
     CONTEXTS = []
     ENTRIES = ['1', '2', '3']
     def __init__(self):
-        super(DoubleContinuation1, self).__init__()
+        super().__init__()
         self.count = 0
         self.ccount = 0
     def continuation(self, context, obj, token=None):
@@ -333,11 +333,11 @@ class DoubleContinuation1(ContinuationFSMAction):
         DoubleContinuation1.CONTEXTS.append(context)
         return 'ok'
 
-class DoubleContinuation2(object):
+class DoubleContinuation2:
     CONTEXTS = []
     ENTRIES = ['a', 'b', 'c']
     def __init__(self):
-        super(DoubleContinuation2, self).__init__()
+        super().__init__()
         self.count = 0
         self.ccount = 0
     def continuation(self, context, obj, token=None):
@@ -355,14 +355,14 @@ class DoubleContinuation2(object):
         DoubleContinuation2.CONTEXTS.append(context)
         return 'okfinal'
 
-class FSCEE_InitialState(object):
+class FSCEE_InitialState:
     def __init__(self):
         self.count = 0
     def execute(self, context, obj):
         self.count += 1
         return 'ok'
 
-class FSCEE_OptionalFinalState(object):
+class FSCEE_OptionalFinalState:
     def __init__(self):
         self.count = 0
     def execute(self, context, obj):
@@ -370,7 +370,7 @@ class FSCEE_OptionalFinalState(object):
         # a final state should be able to emit an event
         return 'ok'
 
-class FSCEE_FinalState(object):
+class FSCEE_FinalState:
     def __init__(self):
         self.count = 0
     def execute(self, context, obj):

--- a/test/fantasm_tests/actions.py
+++ b/test/fantasm_tests/actions.py
@@ -217,7 +217,7 @@ class TestDatastoreContinuationFSMAction(DatastoreContinuationFSMAction):
 
 class TestDatastoreContinuationFSMActionFanInGroupFSMAction(TestDatastoreContinuationFSMAction):
     def execute(self, context, obj):
-        if obj.has_key(CONTINUATION_RESULTS_KEY) and obj[CONTINUATION_RESULTS_KEY]:
+        if CONTINUATION_RESULTS_KEY in obj and obj[CONTINUATION_RESULTS_KEY]:
             context['fan-in-group'] = obj[CONTINUATION_RESULTS_KEY][0].key().id_or_name()
         return super(TestDatastoreContinuationFSMActionFanInGroupFSMAction, self).execute(context, obj)
 

--- a/test/fantasm_tests/config_test.py
+++ b/test/fantasm_tests/config_test.py
@@ -47,7 +47,7 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
 
     def test_nameParsed(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.name, self.machineName)
+        self.assertEqual(fsm.name, self.machineName)
 
     def test_nameRequired(self):
         self.assertRaises(exceptions.MachineNameRequiredError, config._MachineConfig, {})
@@ -66,51 +66,51 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
         useRunOnceSemaphore = not constants.DEFAULT_USE_RUN_ONCE_SEMAPHORE
         self.machineDict[constants.MACHINE_USE_RUN_ONCE_SEMAPHORE_ATTRIBUTE] = useRunOnceSemaphore
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(useRunOnceSemaphore, fsm.useRunOnceSemaphore)
+        self.assertEqual(useRunOnceSemaphore, fsm.useRunOnceSemaphore)
 
     def test_use_datastore_semaphore_hasDefaultValue(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(constants.DEFAULT_USE_RUN_ONCE_SEMAPHORE, fsm.useRunOnceSemaphore)
+        self.assertEqual(constants.DEFAULT_USE_RUN_ONCE_SEMAPHORE, fsm.useRunOnceSemaphore)
 
     def test_queueParsed(self):
         queueName = 'SomeQueue'
         self.machineDict[constants.QUEUE_NAME_ATTRIBUTE] = queueName
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.queueName, queueName)
+        self.assertEqual(fsm.queueName, queueName)
 
     def test_queueHasDefaultValue(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.queueName, constants.DEFAULT_QUEUE_NAME)
+        self.assertEqual(fsm.queueName, constants.DEFAULT_QUEUE_NAME)
 
     def test_countdownParsed(self):
         countdown = 100
         self.machineDict[constants.COUNTDOWN_ATTRIBUTE] = countdown
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.countdown, countdown)
+        self.assertEqual(fsm.countdown, countdown)
 
     def test_countdownHasDefaultValue(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.countdown, constants.DEFAULT_COUNTDOWN)
+        self.assertEqual(fsm.countdown, constants.DEFAULT_COUNTDOWN)
 
     def test_targetParsed(self):
         target = 'some-target'
         self.machineDict[constants.TARGET_ATTRIBUTE] = target
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.target, target)
+        self.assertEqual(fsm.target, target)
 
     def test_targetHasDefaultValue(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.target, constants.DEFAULT_TARGET)
+        self.assertEqual(fsm.target, constants.DEFAULT_TARGET)
 
     def test_noNamespaceYieldNoneAttribute(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.namespace, None)
+        self.assertEqual(fsm.namespace, None)
 
     def test_namespaceParsed(self):
         namespace = 'MyNamespace'
         self.machineDict[constants.NAMESPACE_ATTRIBUTE] = namespace
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.namespace, namespace)
+        self.assertEqual(fsm.namespace, namespace)
 
     def test_maxRetriesInvalidRaisesException(self):
         self.machineDict[constants.MAX_RETRIES_ATTRIBUTE] = 'abc'
@@ -119,18 +119,18 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
     def test_maxRetriesParsed(self):
         self.machineDict[constants.MAX_RETRIES_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.maxRetries, 3)
+        self.assertEqual(fsm.maxRetries, 3)
 
     def test_maxRetriesDefault(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.maxRetries, constants.DEFAULT_TASK_RETRY_LIMIT)
+        self.assertEqual(fsm.maxRetries, constants.DEFAULT_TASK_RETRY_LIMIT)
 
     def test_maxRetriesIssuesDeprecationWarning(self):
         loggingDouble = getLoggingDouble()
         self.machineDict[constants.MAX_RETRIES_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
         self.assertTrue(fsm)
-        self.assertEquals(loggingDouble.count['warning'], 1)
+        self.assertEqual(loggingDouble.count['warning'], 1)
 
     def test_taskRetryLimitInvalidRaisesException(self):
         self.machineDict[constants.TASK_RETRY_LIMIT_ATTRIBUTE] = 'abc'
@@ -139,11 +139,11 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
     def test_taskRetryLimitParsed(self):
         self.machineDict[constants.TASK_RETRY_LIMIT_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.taskRetryLimit, 3)
+        self.assertEqual(fsm.taskRetryLimit, 3)
 
     def test_taskRetryLimitDefault(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.taskRetryLimit, constants.DEFAULT_TASK_RETRY_LIMIT)
+        self.assertEqual(fsm.taskRetryLimit, constants.DEFAULT_TASK_RETRY_LIMIT)
 
     def test_maxRetriesAndTaskRetryLimitRaisesConfigurationError(self):
         self.machineDict[constants.TASK_RETRY_LIMIT_ATTRIBUTE] = '3'
@@ -155,22 +155,22 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
         """ taskRetryLimit and maxRetries should be set to the same value. """
         self.machineDict[constants.TASK_RETRY_LIMIT_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.maxRetries, 3)
+        self.assertEqual(fsm.maxRetries, 3)
 
     def test_settingMaxRetriesSetsTaskRetryLimit(self):
         """ maxRetries and taskRetryLimit should be set to the same value. """
         self.machineDict[constants.MAX_RETRIES_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.taskRetryLimit, 3)
+        self.assertEqual(fsm.taskRetryLimit, 3)
 
     def test_minBackoffSecondsParsed(self):
         self.machineDict[constants.MIN_BACKOFF_SECONDS_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.minBackoffSeconds, 3)
+        self.assertEqual(fsm.minBackoffSeconds, 3)
 
     def test_minBackoffSecondsDefault(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.minBackoffSeconds, constants.DEFAULT_MIN_BACKOFF_SECONDS)
+        self.assertEqual(fsm.minBackoffSeconds, constants.DEFAULT_MIN_BACKOFF_SECONDS)
 
     def test_minBackoffSecondsInvalidRaisesException(self):
         self.machineDict[constants.MIN_BACKOFF_SECONDS_ATTRIBUTE] = 'abc'
@@ -179,11 +179,11 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
     def test_maxBackoffSecondsParsed(self):
         self.machineDict[constants.MAX_BACKOFF_SECONDS_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.maxBackoffSeconds, 3)
+        self.assertEqual(fsm.maxBackoffSeconds, 3)
 
     def test_maxBackoffSecondsDefault(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.maxBackoffSeconds, constants.DEFAULT_MAX_BACKOFF_SECONDS)
+        self.assertEqual(fsm.maxBackoffSeconds, constants.DEFAULT_MAX_BACKOFF_SECONDS)
 
     def test_maxBackoffSecondsInvalidRaisesException(self):
         self.machineDict[constants.MAX_BACKOFF_SECONDS_ATTRIBUTE] = 'abc'
@@ -192,11 +192,11 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
     def test_taskAgeLimitParsed(self):
         self.machineDict[constants.TASK_AGE_LIMIT_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.taskAgeLimit, 3)
+        self.assertEqual(fsm.taskAgeLimit, 3)
 
     def test_taskAgeLimitDefault(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.taskAgeLimit, constants.DEFAULT_TASK_AGE_LIMIT)
+        self.assertEqual(fsm.taskAgeLimit, constants.DEFAULT_TASK_AGE_LIMIT)
 
     def test_taskAgeLimitInvalidRaisesException(self):
         self.machineDict[constants.TASK_AGE_LIMIT_ATTRIBUTE] = 'abc'
@@ -205,11 +205,11 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
     def test_maxDoublingsParsed(self):
         self.machineDict[constants.MAX_DOUBLINGS_ATTRIBUTE] = '3'
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.maxDoublings, 3)
+        self.assertEqual(fsm.maxDoublings, 3)
 
     def test_maxDoublingsDefault(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.maxDoublings, constants.DEFAULT_MAX_DOUBLINGS)
+        self.assertEqual(fsm.maxDoublings, constants.DEFAULT_MAX_DOUBLINGS)
 
     def test_maxDoublingsInvalidRaisesException(self):
         self.machineDict[constants.MAX_DOUBLINGS_ATTRIBUTE] = 'abc'
@@ -221,14 +221,14 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
 
     def test_contextTypesDefault(self):
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(fsm.contextTypes, {})
+        self.assertEqual(fsm.contextTypes, {})
 
     def test_contextTypesParsed(self):
         self.machineDict[constants.MACHINE_CONTEXT_TYPES_ATTRIBUTE] = {
             'counter': 'types.IntType'
         }
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(1, len(fsm.contextTypes))
+        self.assertEqual(1, len(fsm.contextTypes))
         self.assertTrue('counter' in fsm.contextTypes)
 
     def test_contextTypesValueResolved(self):
@@ -237,8 +237,8 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
             'batch-key': 'google.appengine.ext.db.Key'
         }
         fsm = config._MachineConfig(self.machineDict)
-        self.assertEquals(int, fsm.contextTypes['counter'])
-        self.assertEquals(db.Key, fsm.contextTypes['batch-key'])
+        self.assertEqual(int, fsm.contextTypes['counter'])
+        self.assertEqual(db.Key, fsm.contextTypes['batch-key'])
 
     def test_contextTypesBadValueRaisesException(self):
         self.machineDict[constants.NAMESPACE_ATTRIBUTE] = 'namespace'
@@ -263,7 +263,7 @@ class TestStateDictionaryProcessing(unittest.TestCase):
 
     def test_nameParsed(self):
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.name, self.stateDict[constants.STATE_NAME_ATTRIBUTE])
+        self.assertEqual(state.name, self.stateDict[constants.STATE_NAME_ATTRIBUTE])
 
     def test_nameRequired(self):
         self.stateDict.pop(constants.STATE_NAME_ATTRIBUTE)
@@ -287,88 +287,88 @@ class TestStateDictionaryProcessing(unittest.TestCase):
 
     def test_initialDefaultsToFalse(self):
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.initial, False)
+        self.assertEqual(state.initial, False)
 
     def test_initialParsed(self):
         self.stateDict[constants.STATE_INITIAL_ATTRIBUTE] = True
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.initial, True)
+        self.assertEqual(state.initial, True)
 
     def test_finalDefaultsToFalse(self):
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.final, False)
+        self.assertEqual(state.final, False)
 
     def test_finalParsed(self):
         self.stateDict[constants.STATE_FINAL_ATTRIBUTE] = True
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.final, True)
+        self.assertEqual(state.final, True)
 
     def test_continuationDefaultsToFalse(self):
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.continuation, False)
+        self.assertEqual(state.continuation, False)
 
     def test_continuationParsed(self):
         self.stateDict[constants.STATE_ACTION_ATTRIBUTE] = 'MockActionWithContinuation'
         self.stateDict[constants.STATE_CONTINUATION_ATTRIBUTE] = True
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.continuation, True)
+        self.assertEqual(state.continuation, True)
 
     def test_entryResolvedUsingDefaultNamespace(self):
         self.stateDict[constants.STATE_ENTRY_ATTRIBUTE] = 'MockEntry'
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.config_test.MockEntry, state.entry.__class__)
+        self.assertEqual(fantasm_tests.config_test.MockEntry, state.entry.__class__)
 
     def test_exitResolvedUsingDefaultNamespace(self):
         self.stateDict[constants.STATE_EXIT_ATTRIBUTE] = 'MockExit'
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.config_test.MockExit, state.exit.__class__)
+        self.assertEqual(fantasm_tests.config_test.MockExit, state.exit.__class__)
 
     def test_actionResolvedUsingDefaultNamespace(self):
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.config_test.MockAction, state.action.__class__)
+        self.assertEqual(fantasm_tests.config_test.MockAction, state.action.__class__)
 
     def test_entryResolvedUsingFullyQualified(self):
         self.stateDict[constants.STATE_ENTRY_ATTRIBUTE] = 'fantasm_tests.MockEntry2'
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.MockEntry2, state.entry.__class__)
+        self.assertEqual(fantasm_tests.MockEntry2, state.entry.__class__)
 
     def test_exitResolvedUsingFullyQualified(self):
         self.stateDict[constants.STATE_EXIT_ATTRIBUTE] = 'fantasm_tests.MockExit2'
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.MockExit2, state.exit.__class__)
+        self.assertEqual(fantasm_tests.MockExit2, state.exit.__class__)
 
     def test_actionResolvedUsingFullyQualified(self):
         self.stateDict[constants.STATE_ACTION_ATTRIBUTE] = 'fantasm_tests.MockAction2'
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.MockAction2, state.action.__class__)
+        self.assertEqual(fantasm_tests.MockAction2, state.action.__class__)
 
     def test_entryResolvedUsingStateOverride(self):
         self.stateDict[constants.NAMESPACE_ATTRIBUTE] = 'fantasm_tests'
         self.stateDict[constants.STATE_ENTRY_ATTRIBUTE] = 'MockEntry2'
         self.stateDict[constants.STATE_ACTION_ATTRIBUTE] = 'MockAction2'
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.MockEntry2, state.entry.__class__)
+        self.assertEqual(fantasm_tests.MockEntry2, state.entry.__class__)
 
     def test_exitResolvedUsingStateOverride(self):
         self.stateDict[constants.NAMESPACE_ATTRIBUTE] = 'fantasm_tests'
         self.stateDict[constants.STATE_EXIT_ATTRIBUTE] = 'MockExit2'
         self.stateDict[constants.STATE_ACTION_ATTRIBUTE] = 'MockAction2'
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.MockExit2, state.exit.__class__)
+        self.assertEqual(fantasm_tests.MockExit2, state.exit.__class__)
 
     def test_actionResolvedUsingStateOverride(self):
         self.stateDict[constants.NAMESPACE_ATTRIBUTE] = 'fantasm_tests'
         self.stateDict[constants.STATE_ACTION_ATTRIBUTE] = 'MockAction2'
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(fantasm_tests.MockAction2, state.action.__class__)
+        self.assertEqual(fantasm_tests.MockAction2, state.action.__class__)
 
     def test_noEntryYieldsNoneEntry(self):
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.entry, None)
+        self.assertEqual(state.entry, None)
 
     def test_noExitYieldsNoneExit(self):
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.exit, None)
+        self.assertEqual(state.exit, None)
 
     def test_unresolvedEntryYieldsException(self):
         self.stateDict[constants.STATE_ENTRY_ATTRIBUTE] = 'VeryBadClass'
@@ -399,7 +399,7 @@ class TestStateDictionaryProcessing(unittest.TestCase):
         self.stateDict[constants.STATE_CONTINUATION_ATTRIBUTE] = False
         self.stateDict[constants.STATE_ACTION_ATTRIBUTE] = 'MockActionWithContinuation'
         self.fsm.addState(self.stateDict)
-        self.assertEquals(loggingDouble.count['warning'], 1)
+        self.assertEqual(loggingDouble.count['warning'], 1)
 
     def test_actionSpecifiedButNoExecuteMethodRaisesException(self):
         self.stateDict[constants.STATE_ACTION_ATTRIBUTE] = 'MockActionNoExecute'
@@ -415,7 +415,7 @@ class TestStateDictionaryProcessing(unittest.TestCase):
 
     def test_faninDefaultToNoFanIn(self):
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.fanInPeriod, constants.NO_FAN_IN)
+        self.assertEqual(state.fanInPeriod, constants.NO_FAN_IN)
 
     def test_faninMustBeAnInteger(self):
         self.stateDict[constants.STATE_FAN_IN_ATTRIBUTE] = 'abc'
@@ -428,7 +428,7 @@ class TestStateDictionaryProcessing(unittest.TestCase):
     def test_faninParsed(self):
         self.stateDict[constants.STATE_FAN_IN_ATTRIBUTE] = 10
         state = self.fsm.addState(self.stateDict)
-        self.assertEquals(state.fanInPeriod, 10)
+        self.assertEqual(state.fanInPeriod, 10)
 
     def test_faninCombinedWithContinuationRaisesException(self):
         self.stateDict[constants.STATE_FAN_IN_ATTRIBUTE] = 10
@@ -451,11 +451,11 @@ class TestMachineUrlConstruction(unittest.TestCase):
 
     def test_urlIncludesHostName(self):
         fsm = config._MachineConfig({constants.MACHINE_NAME_ATTRIBUTE: 'MyMachine'})
-        self.assertEquals(fsm.url, '%sfsm/MyMachine/' % constants.DEFAULT_ROOT_URL)
+        self.assertEqual(fsm.url, '%sfsm/MyMachine/' % constants.DEFAULT_ROOT_URL)
 
     def test_rootUrlOverridesDefault(self):
         fsm = config._MachineConfig({constants.MACHINE_NAME_ATTRIBUTE: 'MyMachine'}, rootUrl='/myfsm')
-        self.assertEquals(fsm.url, '/myfsm/fsm/MyMachine/')
+        self.assertEqual(fsm.url, '/myfsm/fsm/MyMachine/')
 
 class TestTransitionDictionaryProcessing(unittest.TestCase):
 
@@ -480,7 +480,7 @@ class TestTransitionDictionaryProcessing(unittest.TestCase):
 
     def test_nameGenerated(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.name, 'GoodState--MyEvent')
+        self.assertEqual(transition.name, 'GoodState--MyEvent')
 
     def test_eventRequired(self):
         self.transDict.pop(constants.TRANS_EVENT_ATTRIBUTE)
@@ -498,7 +498,7 @@ class TestTransitionDictionaryProcessing(unittest.TestCase):
 
     def test_eventParsed(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.event, self.transDict[constants.TRANS_EVENT_ATTRIBUTE])
+        self.assertEqual(transition.event, self.transDict[constants.TRANS_EVENT_ATTRIBUTE])
 
     def test_toRequired(self):
         self.transDict.pop(constants.TRANS_TO_ATTRIBUTE)
@@ -510,27 +510,27 @@ class TestTransitionDictionaryProcessing(unittest.TestCase):
 
     def test_toParsed(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.toState, self.goodState)
+        self.assertEqual(transition.toState, self.goodState)
 
     def test_noActionYieldsNoneAttribute(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.action, None)
+        self.assertEqual(transition.action, None)
 
     def test_actionResolvedUsingDefaultNamespace(self):
         self.transDict[constants.TRANS_ACTION_ATTRIBUTE] = 'MockAction'
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(fantasm_tests.config_test.MockAction, transition.action.__class__)
+        self.assertEqual(fantasm_tests.config_test.MockAction, transition.action.__class__)
 
     def test_actionResolvedUsingFullyQualified(self):
         self.transDict[constants.TRANS_ACTION_ATTRIBUTE] = 'fantasm_tests.MockAction2'
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(fantasm_tests.MockAction2, transition.action.__class__)
+        self.assertEqual(fantasm_tests.MockAction2, transition.action.__class__)
 
     def test_actionResolvedUsingStateOverride(self):
         self.transDict[constants.NAMESPACE_ATTRIBUTE] = 'fantasm_tests'
         self.transDict[constants.TRANS_ACTION_ATTRIBUTE] = 'MockAction2'
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(fantasm_tests.MockAction2, transition.action.__class__)
+        self.assertEqual(fantasm_tests.MockAction2, transition.action.__class__)
 
     def test_unresolvedActionYieldsException(self):
         self.transDict[constants.TRANS_ACTION_ATTRIBUTE] = 'VeryBadClass'
@@ -548,36 +548,36 @@ class TestTransitionDictionaryProcessing(unittest.TestCase):
 
     def test_maxRetriesInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.maxRetries, 100)
+        self.assertEqual(transition.maxRetries, 100)
 
     def test_queueNameInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.queueName, 'somequeue')
+        self.assertEqual(transition.queueName, 'somequeue')
 
     def test_queueNameOverridesMachineQueueName(self):
         self.transDict[constants.QUEUE_NAME_ATTRIBUTE] = 'someotherqueue'
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.queueName, 'someotherqueue')
+        self.assertEqual(transition.queueName, 'someotherqueue')
 
     def test_targetInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.target, 'some-target')
+        self.assertEqual(transition.target, 'some-target')
 
     def test_targetOverridesMachineQueueName(self):
         self.transDict[constants.TARGET_ATTRIBUTE] = 'some-other-target'
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.target, 'some-other-target')
+        self.assertEqual(transition.target, 'some-other-target')
 
     def test_maxRetriesOverridesMachineRetryPolicy(self):
         self.transDict[constants.MAX_RETRIES_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.maxRetries, 99)
+        self.assertEqual(transition.maxRetries, 99)
 
     def test_maxRetriesEmitsDeprecationWarning(self):
         loggingDouble = getLoggingDouble()
         self.transDict[constants.MAX_RETRIES_ATTRIBUTE] = '3'
         self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(loggingDouble.count['warning'], 1)
+        self.assertEqual(loggingDouble.count['warning'], 1)
 
     def test_maxRetriesAndTaskRetryLimitCannotBothBeSpecified(self):
         self.transDict[constants.MAX_RETRIES_ATTRIBUTE] = 99
@@ -588,57 +588,57 @@ class TestTransitionDictionaryProcessing(unittest.TestCase):
     def test_settingMaxRetriesSetsTaskRetryLimit(self):
         self.transDict[constants.MAX_RETRIES_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.taskRetryLimit, 99)
+        self.assertEqual(transition.taskRetryLimit, 99)
 
     def test_settingTaskRetryLimitSetsMaxRetries(self):
         self.transDict[constants.TASK_RETRY_LIMIT_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.maxRetries, 99)
+        self.assertEqual(transition.maxRetries, 99)
 
     def test_taskRetryLimitInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.taskRetryLimit, 100)
+        self.assertEqual(transition.taskRetryLimit, 100)
 
     def test_taskRetryLimitOverridesMachineTaskRetryLimit(self):
         self.transDict[constants.TASK_RETRY_LIMIT_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.taskRetryLimit, 99)
+        self.assertEqual(transition.taskRetryLimit, 99)
 
     def test_minBackoffSecondsInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.minBackoffSeconds, 101)
+        self.assertEqual(transition.minBackoffSeconds, 101)
 
     def test_minBackoffSecondsOverridesMachineTaskRetryLimit(self):
         self.transDict[constants.MIN_BACKOFF_SECONDS_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.minBackoffSeconds, 99)
+        self.assertEqual(transition.minBackoffSeconds, 99)
 
     def test_maxBackoffSecondsInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.maxBackoffSeconds, 102)
+        self.assertEqual(transition.maxBackoffSeconds, 102)
 
     def test_maxBackoffSecondsOverridesMachineTaskRetryLimit(self):
         self.transDict[constants.MAX_BACKOFF_SECONDS_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.maxBackoffSeconds, 99)
+        self.assertEqual(transition.maxBackoffSeconds, 99)
 
     def test_taskAgeLimitInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.taskAgeLimit, 103)
+        self.assertEqual(transition.taskAgeLimit, 103)
 
     def test_taskAgeLimitOverridesMachineTaskRetryLimit(self):
         self.transDict[constants.TASK_AGE_LIMIT_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.taskAgeLimit, 99)
+        self.assertEqual(transition.taskAgeLimit, 99)
 
     def test_maxDoublingsInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.maxDoublings, 104)
+        self.assertEqual(transition.maxDoublings, 104)
 
     def test_maxDoublingsOverridesMachineTaskRetryLimit(self):
         self.transDict[constants.MAX_DOUBLINGS_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.maxDoublings, 99)
+        self.assertEqual(transition.maxDoublings, 99)
 
     def test_transitionActionOnContinuationRaisesException(self):
         self.goodState.continuation = True
@@ -658,7 +658,7 @@ class TestTransitionDictionaryProcessing(unittest.TestCase):
         d = {'minimum': 30, 'maximum': 60}
         self.transDict[constants.COUNTDOWN_ATTRIBUTE] = d
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.countdown, (30, 60)) # converted to a tuple
+        self.assertEqual(transition.countdown, (30, 60)) # converted to a tuple
 
     def test_countdownMustHaveMinimumIfDictionary(self):
         d = {'maximum': 60}
@@ -698,16 +698,16 @@ class TestTransitionDictionaryProcessing(unittest.TestCase):
     def test_countdownParsed(self):
         self.transDict[constants.COUNTDOWN_ATTRIBUTE] = 10
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.countdown, 10)
+        self.assertEqual(transition.countdown, 10)
 
     def test_countdownInheritedFromMachine(self):
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.countdown, 100)
+        self.assertEqual(transition.countdown, 100)
 
     def test_countdownOverridesMachineQueueName(self):
         self.transDict[constants.COUNTDOWN_ATTRIBUTE] = 99
         transition = self.fsm.addTransition(self.transDict, 'GoodState')
-        self.assertEquals(transition.countdown, 99)
+        self.assertEqual(transition.countdown, 99)
 
 class TestAdvancedTransitionDictionaryProcessing(unittest.TestCase):
 
@@ -794,13 +794,13 @@ class TestConfigDictionaryProcessing(unittest.TestCase):
 
     def test_rootUrlPassedToMachines(self):
         configuration = config.Configuration(self.baseDict)
-        self.assertEquals(configuration.rootUrl, self.rootUrl)
+        self.assertEqual(configuration.rootUrl, self.rootUrl)
         self.assertTrue(configuration.machines[self.machineName].url.startswith(self.rootUrl))
 
     def test_rootUrlHasDefault(self):
         self.baseDict.pop(constants.ROOT_URL_ATTRIBUTE)
         configuration = config.Configuration(self.baseDict)
-        self.assertEquals(configuration.rootUrl, constants.DEFAULT_ROOT_URL)
+        self.assertEqual(configuration.rootUrl, constants.DEFAULT_ROOT_URL)
 
     def test_machinesMustHaveUniqueNames(self):
         self.baseDict[constants.STATE_MACHINES_ATTRIBUTE].append(
@@ -834,15 +834,15 @@ class TestConfigDictionaryProcessing(unittest.TestCase):
             }
         )
         configuration = config.Configuration(self.baseDict)
-        self.assertEquals(configuration.machines[self.machineName].name, self.machineName)
-        self.assertEquals(configuration.machines[otherMachineName].name, otherMachineName)
+        self.assertEqual(configuration.machines[self.machineName].name, self.machineName)
+        self.assertEqual(configuration.machines[otherMachineName].name, otherMachineName)
 
     def test_statesAddedToMachines(self):
         configuration = config.Configuration(self.baseDict)
         myMachine = configuration.machines[self.machineName]
-        self.assertEquals(len(myMachine.states), 2)
-        self.assertEquals(myMachine.states[self.initialStateName].name, self.initialStateName)
-        self.assertEquals(myMachine.states[self.finalStateName].name, self.finalStateName)
+        self.assertEqual(len(myMachine.states), 2)
+        self.assertEqual(myMachine.states[self.initialStateName].name, self.initialStateName)
+        self.assertEqual(myMachine.states[self.finalStateName].name, self.finalStateName)
 
     def test_machineWithNoInitialRaisesException(self):
         # this is hairy, but I'm going to clear the initial flag on the state
@@ -863,11 +863,11 @@ class TestConfigDictionaryProcessing(unittest.TestCase):
     def test_transitionsAddedToMachines(self):
         configuration = config.Configuration(self.baseDict)
         myMachine = configuration.machines[self.machineName]
-        self.assertEquals(len(myMachine.transitions), 2)
+        self.assertEqual(len(myMachine.transitions), 2)
         trans1Name = self.initialStateName + '--event1'
         trans2Name = self.initialStateName + '--event2'
-        self.assertEquals(myMachine.transitions[trans1Name].name, trans1Name)
-        self.assertEquals(myMachine.transitions[trans2Name].name, trans2Name)
+        self.assertEqual(myMachine.transitions[trans1Name].name, trans1Name)
+        self.assertEqual(myMachine.transitions[trans2Name].name, trans2Name)
 
     def test_stateMachineAttributeRequired(self):
         self.assertRaises(exceptions.StateMachinesAttributeRequiredError, config.Configuration, {})
@@ -898,8 +898,8 @@ class TestNamespacedEventsAndContextTypes(unittest.TestCase):
 
     def _test(self, yamlString):
         """ just tests that it can be built """
-        import StringIO, yaml
-        yamlFile = StringIO.StringIO()
+        import io, yaml
+        yamlFile = io.StringIO()
         yamlFile.write(yamlString)
         yamlFile.seek(0)
         configDict = yaml.load(yamlFile.read())
@@ -1038,7 +1038,7 @@ state_machines:
             configuration.machines['machineName'].transitions['state1--just-a-plain-old-string'].event
         )
         self.assertEqual(
-            {'NAMESPACED-CONTEXT-TYPE-CLASS-LEVEL-FSM-TESTS': int, 'abc': long},
+            {'NAMESPACED-CONTEXT-TYPE-CLASS-LEVEL-FSM-TESTS': int, 'abc': int},
             configuration.machines['machineName'].contextTypes
         )
 
@@ -1085,8 +1085,8 @@ class TestStatesWithAndWithoutDoActions(unittest.TestCase):
 
     def _test(self, yamlString):
         """ just tests that it can be built """
-        import StringIO, yaml
-        yamlFile = StringIO.StringIO()
+        import io, yaml
+        yamlFile = io.StringIO()
         yamlFile.write(yamlString)
         yamlFile.seek(0)
         configDict = yaml.load(yamlFile.read())

--- a/test/fantasm_tests/config_test.py
+++ b/test/fantasm_tests/config_test.py
@@ -902,7 +902,7 @@ class TestNamespacedEventsAndContextTypes(unittest.TestCase):
         yamlFile = io.StringIO()
         yamlFile.write(yamlString)
         yamlFile.seek(0)
-        configDict = yaml.load(yamlFile.read())
+        configDict = yaml.safe_load(yamlFile.read())
         configuration = config.Configuration(configDict)
         return configuration
 
@@ -1089,7 +1089,7 @@ class TestStatesWithAndWithoutDoActions(unittest.TestCase):
         yamlFile = io.StringIO()
         yamlFile.write(yamlString)
         yamlFile.seek(0)
-        configDict = yaml.load(yamlFile.read())
+        configDict = yaml.safe_load(yamlFile.read())
         configuration = config.Configuration(configDict)
         self.assertTrue(configuration)
 

--- a/test/fantasm_tests/config_test.py
+++ b/test/fantasm_tests/config_test.py
@@ -13,36 +13,36 @@ from minimock import restore
 # - accessing protected config members a lot in these tests
 
 # the following classes are used for namespace and interface testing
-class MockAction(object):
+class MockAction:
     def execute(self, context, obj):
         pass
-class MockEntry(object):
+class MockEntry:
     def execute(self, context, obj):
         pass
-class MockExit(object):
+class MockExit:
     def execute(self, context, obj):
         pass
-class MockActionWithContinuation(object):
+class MockActionWithContinuation:
     def continuation(self, context, obj, token):
         pass
     def execute(self, context, obj):
         pass
-class MockActionNoExecute(object):
+class MockActionNoExecute:
     pass
-class MockEntryNoExecute(object):
+class MockEntryNoExecute:
     pass
-class MockExitNoExecute(object):
+class MockExitNoExecute:
     pass
 
 class TestMachineDictionaryProcessing(unittest.TestCase):
 
     def setUp(self):
-        super(TestMachineDictionaryProcessing, self).setUp()
+        super().setUp()
         self.machineName = 'MyMachine'
         self.machineDict = {constants.MACHINE_NAME_ATTRIBUTE: self.machineName}
 
     def tearDown(self):
-        super(TestMachineDictionaryProcessing, self).tearDown()
+        super().tearDown()
         restore()
 
     def test_nameParsed(self):
@@ -250,7 +250,7 @@ class TestMachineDictionaryProcessing(unittest.TestCase):
 class TestStateDictionaryProcessing(unittest.TestCase):
 
     def setUp(self):
-        super(TestStateDictionaryProcessing, self).setUp()
+        super().setUp()
         self.machineName = 'MyFsm'
         self.fsm = config._MachineConfig({constants.MACHINE_NAME_ATTRIBUTE: self.machineName})
         self.stateDict = {constants.STATE_NAME_ATTRIBUTE: 'MyState',
@@ -258,7 +258,7 @@ class TestStateDictionaryProcessing(unittest.TestCase):
                           constants.NAMESPACE_ATTRIBUTE: 'fantasm_tests.config_test'}
 
     def tearDown(self):
-        super(TestStateDictionaryProcessing, self).tearDown()
+        super().tearDown()
         restore()
 
     def test_nameParsed(self):
@@ -460,7 +460,7 @@ class TestMachineUrlConstruction(unittest.TestCase):
 class TestTransitionDictionaryProcessing(unittest.TestCase):
 
     def setUp(self):
-        super(TestTransitionDictionaryProcessing, self).setUp()
+        super().setUp()
         self.transDict = {
             constants.TRANS_EVENT_ATTRIBUTE: 'MyEvent',
             constants.TRANS_TO_ATTRIBUTE: 'GoodState'
@@ -712,7 +712,7 @@ class TestTransitionDictionaryProcessing(unittest.TestCase):
 class TestAdvancedTransitionDictionaryProcessing(unittest.TestCase):
 
     def setUp(self):
-        super(TestAdvancedTransitionDictionaryProcessing, self).setUp()
+        super().setUp()
         self.transDict = {
             constants.TRANS_EVENT_ATTRIBUTE: 'MyEvent',
             constants.TRANS_TO_ATTRIBUTE: 'state2'
@@ -753,7 +753,7 @@ class TestAdvancedTransitionDictionaryProcessing(unittest.TestCase):
 class TestConfigDictionaryProcessing(unittest.TestCase):
 
     def setUp(self):
-        super(TestConfigDictionaryProcessing, self).setUp()
+        super().setUp()
         self.rootUrl = '/foo/'
         self.machineName = 'MyMachine'
         self.initialStateName = 'MyInitialState'

--- a/test/fantasm_tests/continuation_fan_in_test.py
+++ b/test/fantasm_tests/continuation_fan_in_test.py
@@ -62,11 +62,11 @@ class OutsideListContinuationAction( ListContinuation ):
             context['data'] = obj[CONTINUATION_RESULTS_KEY]
         return context.get('event', 'ok') # bad!!! should be inside if
 
-class MiddleAction( object ):
+class MiddleAction:
     def execute(self, context, obj):
         return 'ok'
 
-class FanInAction( object ):
+class FanInAction:
     def execute(self, contexts, obj):
         for context in contexts:
             result = ContinuationFanInResult.get_or_insert('test')
@@ -217,7 +217,7 @@ class BaseTest( AppEngineTestCase ):
     EVENT = None
 
     def setUp(self):
-        super(BaseTest, self).setUp()
+        super().setUp()
         setUpByString(self, FAN_IN_MACHINE, machineName=self.MACHINE_NAME)
         mock('config.currentConfiguration', returns=self.currentConfig, tracker=None)
         mock('FSMFanInCleanupHandler.post', returns=None, tracker=None)
@@ -226,7 +226,7 @@ class BaseTest( AppEngineTestCase ):
         self.context['event'] = self.EVENT
 
     def tearDown(self):
-        super(BaseTest, self).tearDown()
+        super().tearDown()
         restore()
 
 

--- a/test/fantasm_tests/fixtures.py
+++ b/test/fantasm_tests/fixtures.py
@@ -36,7 +36,7 @@ class AppEngineTestCase(unittest.TestCase):
         tq.GetTasks('default')
         # pylint: disable=W0212
         # - workaround to prevent GetTasks from re-parsing queue.yaml on every call
-        for value in (tq._queues or {}).values():
+        for value in list((tq._queues or {}).values()):
             value._queue_yaml_parser = None
 
         self.__urlfetch = urlfetch_stub.URLFetchServiceStub()

--- a/test/fantasm_tests/fixtures.py
+++ b/test/fantasm_tests/fixtures.py
@@ -18,7 +18,7 @@ os.environ['HTTP_HOST'] = 'fantasm'
 class AppEngineTestCase(unittest.TestCase):
 
     def setUp(self):
-        super(AppEngineTestCase, self).setUp()
+        super().setUp()
 
         # save the apiproxy
         self.__origApiproxy = apiproxy_stub_map.apiproxy
@@ -56,7 +56,7 @@ class AppEngineTestCase(unittest.TestCase):
         constants.DEFAULT_LOG_QUEUE_NAME = constants.DEFAULT_QUEUE_NAME
 
     def tearDown(self):
-        super(AppEngineTestCase, self).tearDown()
+        super().tearDown()
 
         # restore the apiproxy
         apiproxy_stub_map.apiproxy = self.__origApiproxy

--- a/test/fantasm_tests/fsm_test.py
+++ b/test/fantasm_tests/fsm_test.py
@@ -100,7 +100,7 @@ class FSMTests(unittest.TestCase):
 class FSMContextTests(unittest.TestCase):
 
     def setUp(self):
-        super(FSMContextTests, self).setUp()
+        super().setUp()
         filename = 'test-FSMContextTests.yaml'
         setUpByFilename(self, filename)
         self.machineName = getMachineNameByFilename(filename)
@@ -112,7 +112,7 @@ class FSMContextTests(unittest.TestCase):
         self.context.dispatch(FSM.PSEUDO_INIT, self.obj)
 
     def tearDown(self):
-        super(FSMContextTests, self).tearDown()
+        super().tearDown()
         restore()
 
     def getContextWithoutSpecialEntries(self):
@@ -200,7 +200,7 @@ class FSMContextTests(unittest.TestCase):
 class FSMContextMergeJoinTests(AppEngineTestCase):
 
     def setUp(self):
-        super(FSMContextMergeJoinTests, self).setUp()
+        super().setUp()
         self.state = State('foo', None, CountExecuteCalls(), None)
         self.state2 = State('foo2', None, CountExecuteCallsWithFork(), None)
         self.state.addTransition(Transition('t1', self.state2, queueName='q'), 'event')
@@ -236,7 +236,7 @@ class FSMContextMergeJoinTests(AppEngineTestCase):
 class TaskQueueFSMTests(AppEngineTestCase):
 
     def setUp(self):
-        super(TaskQueueFSMTests, self).setUp()
+        super().setUp()
         self.maxDiff = None
         filename = 'test-TaskQueueFSMTests.yaml'
         setUpByFilename(self, filename)
@@ -250,18 +250,18 @@ class TaskQueueFSMTests(AppEngineTestCase):
         self.transNormalToFinal = self.stateNormal._eventToTransition['next-event']
 
     def tearDown(self):
-        super(TaskQueueFSMTests, self).tearDown()
+        super().tearDown()
         restore()
 
     def assertTaskUrlHasStateAndEvent(self, task, expectedState, expectedEvent):
         # '/fantasm/fsm/TaskQueueFSMTests/?__st__=state-normal&__ev__=next-event&arg1=val1&arg2=val2'
-        stateParams = '%s=%s' % (STATE_PARAM, expectedState)
-        eventParams = '%s=%s' % (EVENT_PARAM, expectedEvent)
+        stateParams = '{}={}'.format(STATE_PARAM, expectedState)
+        eventParams = '{}={}'.format(EVENT_PARAM, expectedEvent)
         self.assertTrue(stateParams in task.url)
         self.assertTrue(eventParams in task.url)
 
     def assertTaskUrlHasInstanceName(self, task, instanceName):
-        instanceParams = '%s=%s' % (INSTANCE_NAME_PARAM, instanceName)
+        instanceParams = '{}={}'.format(INSTANCE_NAME_PARAM, instanceName)
         self.assertTrue(instanceParams in task.url)
 
     def test_initialialize_counts(self):
@@ -471,7 +471,7 @@ class TaskQueueFSMTests(AppEngineTestCase):
 class TaskQueueFSMRandomCountdownTests(AppEngineTestCase):
 
     def setUp(self):
-        super(TaskQueueFSMRandomCountdownTests, self).setUp()
+        super().setUp()
         self.maxDiff = None
         filename = 'test-TaskQueueFSMRandomCountdownTests.yaml'
         setUpByFilename(self, filename)
@@ -485,7 +485,7 @@ class TaskQueueFSMRandomCountdownTests(AppEngineTestCase):
         self.transNormalToFinal = self.stateNormal._eventToTransition['next-event']
 
     def tearDown(self):
-        super(TaskQueueFSMRandomCountdownTests, self).tearDown()
+        super().tearDown()
         restore()
 
     def test_normalStateDispatchUsesRandomCountdown(self):
@@ -516,7 +516,7 @@ _UTC = _UTCTimeZone()
 class TaskQueueFSMRetryTests(AppEngineTestCase):
 
     def setUp(self):
-        super(TaskQueueFSMRetryTests, self).setUp()
+        super().setUp()
         filename = 'test-TaskQueueFSMRetryTests.yaml'
         machineName = getMachineNameByFilename(filename)
         self.factory = getFSMFactoryByFilename(filename)
@@ -531,7 +531,7 @@ class TaskQueueFSMRetryTests(AppEngineTestCase):
         self.mockQueue.purge() # clear the initialization task
 
     def tearDown(self):
-        super(TaskQueueFSMRetryTests, self).tearDown()
+        super().tearDown()
         restore()
 
     def test_taskRetryLimitAddedToQueuedTask(self):
@@ -588,7 +588,7 @@ class DatastoreFSMContinuationBaseTests(AppEngineTestCase):
     MACHINE_NAME = None
 
     def setUp(self):
-        super(DatastoreFSMContinuationBaseTests, self).setUp()
+        super().setUp()
         setUpByFilename(self, self.FILENAME, instanceName='instanceName', machineName=self.MACHINE_NAME)
         self.mockQueue = TaskQueueDouble()
         mock(name='Queue.add', returns_func=self.mockQueue.add, tracker=None)
@@ -599,7 +599,7 @@ class DatastoreFSMContinuationBaseTests(AppEngineTestCase):
             self.modelKeys.append(modelKey)
 
     def tearDown(self):
-        super(DatastoreFSMContinuationBaseTests, self).tearDown()
+        super().tearDown()
         restore()
 
 class DatastoreFSMContinuationWithContinuationCountdownTests(DatastoreFSMContinuationBaseTests):
@@ -859,7 +859,7 @@ class NDBDatastoreFSMContinuationTests(AppEngineTestCase):
     MACHINE_NAME = 'NDBDatastoreFSMContinuationTests'
 
     def setUp(self):
-        super(NDBDatastoreFSMContinuationTests, self).setUp()
+        super().setUp()
         setUpByFilename(self, self.FILENAME, instanceName='instanceName', machineName=self.MACHINE_NAME)
         self.mockQueue = TaskQueueDouble()
         mock(name='Queue.add', returns_func=self.mockQueue.add, tracker=None)
@@ -870,7 +870,7 @@ class NDBDatastoreFSMContinuationTests(AppEngineTestCase):
             self.modelKeys.append(modelKey)
 
     def tearDown(self):
-        super(NDBDatastoreFSMContinuationTests, self).tearDown()
+        super().tearDown()
         restore()
 
     def test_NDBDatastoreFSMContinuation_smoke_test(self):
@@ -982,7 +982,7 @@ class NDBDatastoreFSMContinuationTests(AppEngineTestCase):
 class ContextTypesCoercionTests(unittest.TestCase):
 
     def setUp(self):
-        super(ContextTypesCoercionTests, self).setUp()
+        super().setUp()
         setUpByFilename(self, 'test-TypeCoercionTests.yaml')
 
     def test_incomingItemsArePlacedIntoContextAsCorrectDatatype(self):
@@ -1016,7 +1016,7 @@ class ContextTypesCoercionTests(unittest.TestCase):
 class ContextYamlImportTests(unittest.TestCase):
 
     def setUp(self):
-        super(ContextYamlImportTests, self).setUp()
+        super().setUp()
 
     def test_imports_only(self):
         setUpByFilename(self, 'test-YamlImportOnly.yaml', machineName='TypeCoercionTests')
@@ -1044,7 +1044,7 @@ class ContextYamlImportTests(unittest.TestCase):
 class SpawnTests(unittest.TestCase):
 
     def setUp(self):
-        super(SpawnTests, self).setUp()
+        super().setUp()
         filename = 'test-TaskQueueFSMTests.yaml'
         setUpByFilename(self, filename)
         self.machineName = getMachineNameByFilename(filename)
@@ -1059,7 +1059,7 @@ class SpawnTests(unittest.TestCase):
         self.mockQueue.purge()
 
     def tearDown(self):
-        super(SpawnTests, self).tearDown()
+        super().tearDown()
         restore()
 
     def getTask(self, num):
@@ -1105,7 +1105,7 @@ class StartStateMachineTests(unittest.TestCase):
     """ Tests for startStateMachine """
 
     def setUp(self):
-        super(StartStateMachineTests, self).setUp()
+        super().setUp()
         filename = 'test-TaskQueueFSMTests.yaml'
         setUpByFilename(self, filename)
         self.machineName = getMachineNameByFilename(filename)
@@ -1113,7 +1113,7 @@ class StartStateMachineTests(unittest.TestCase):
         mock(name='Queue.add', returns_func=self.mockQueue.add, tracker=None)
 
     def tearDown(self):
-        super(StartStateMachineTests, self).tearDown()
+        super().tearDown()
         restore()
 
     def getTask(self, num):
@@ -1145,7 +1145,7 @@ class StartStateMachineTests(unittest.TestCase):
 
     def test_correctUrlInTask(self):
         startStateMachine(self.machineName, {'a': '1'}, _currentConfig=self.currentConfig, method='POST')
-        self.assertEqual(self.getTask(0).url, '/fantasm/fsm/%s/%s/%s/%s/' % (self.machineName,
+        self.assertEqual(self.getTask(0).url, '/fantasm/fsm/{}/{}/{}/{}/'.format(self.machineName,
                                                                               FSM.PSEUDO_INIT,
                                                                               FSM.PSEUDO_INIT,
                                                                               self.initialState.name))
@@ -1228,14 +1228,14 @@ class HaltMachineErrorTest(AppEngineTestCase):
     MACHINE_NAME = None
 
     def setUp(self):
-        super(HaltMachineErrorTest, self).setUp()
+        super().setUp()
         setUpByFilename(self, self.FILENAME, instanceName='instanceName', machineName=self.MACHINE_NAME)
         self.mockQueue = TaskQueueDouble()
         mock(name='Queue.add', returns_func=self.mockQueue.add, tracker=None)
         self.loggingDouble = getLoggingDouble()
 
     def tearDown(self):
-        super(HaltMachineErrorTest, self).tearDown()
+        super().tearDown()
         restore()
 
 class HaltMachineErrorEntryTests(HaltMachineErrorTest):

--- a/test/fantasm_tests/handlers_test.py
+++ b/test/fantasm_tests/handlers_test.py
@@ -10,7 +10,7 @@ from fantasm.handlers import getMachineNameFromRequest
 from fantasm import config # pylint: disable=W0611
                            # - actually used by minimock
 
-class MockConfigRootUrl(object):
+class MockConfigRootUrl:
     """ Simple mock config. """
     def __init__(self, rootUrl):
         """ Initialize. """
@@ -20,11 +20,11 @@ class GetMachineNameFromRequestTests(unittest.TestCase):
     """ Tests for getMachineNameFromRequest """
 
     def setUp(self):
-        super(GetMachineNameFromRequestTests, self).setUp()
+        super().setUp()
         mock('config.currentConfiguration', returns=MockConfigRootUrl('/fantasm/'), tracker=None)
 
     def tearDown(self):
-        super(GetMachineNameFromRequestTests, self).tearDown()
+        super().tearDown()
         restore()
 
     def test_defaultMountPointNoExtraPathInfo(self):

--- a/test/fantasm_tests/handlers_test.py
+++ b/test/fantasm_tests/handlers_test.py
@@ -31,44 +31,44 @@ class GetMachineNameFromRequestTests(unittest.TestCase):
         url = '/fantasm/fsm/MyMachine/'
         request = buildRequest(path=url)
         name = getMachineNameFromRequest(request)
-        self.assertEquals(name, 'MyMachine')
+        self.assertEqual(name, 'MyMachine')
 
     def test_defaultMountPointExtraPathInfo(self):
         url = '/fantasm/fsm/MyMachine/state1/to/state2/'
         request = buildRequest(path=url)
         name = getMachineNameFromRequest(request)
-        self.assertEquals(name, 'MyMachine')
+        self.assertEqual(name, 'MyMachine')
 
     def test_graphvizMapping(self):
         url = '/fantasm/graphviz/MyMachine/'
         request = buildRequest(path=url)
         name = getMachineNameFromRequest(request)
-        self.assertEquals(name, 'MyMachine')
+        self.assertEqual(name, 'MyMachine')
 
     def test_singleLevelMountPointNoExtraPathInfo(self):
         url = '/o/fsm/MyMachine/'
         request = buildRequest(path=url)
         mock('config.currentConfiguration', returns=MockConfigRootUrl('/o/'), tracker=None)
         name = getMachineNameFromRequest(request)
-        self.assertEquals(name, 'MyMachine')
+        self.assertEqual(name, 'MyMachine')
 
     def test_singleLevelMountPointExtraPathInfo(self):
         url = '/o/fsm/MyMachine/state1/to/state2'
         request = buildRequest(path=url)
         mock('config.currentConfiguration', returns=MockConfigRootUrl('/o/'), tracker=None)
         name = getMachineNameFromRequest(request)
-        self.assertEquals(name, 'MyMachine')
+        self.assertEqual(name, 'MyMachine')
 
     def test_multipleLevelMountPointNoExtraPathInfo(self):
         url = '/other/mount/point/fsm/MyMachine/'
         request = buildRequest(path=url)
         mock('config.currentConfiguration', returns=MockConfigRootUrl('/other/mount/point/'), tracker=None)
         name = getMachineNameFromRequest(request)
-        self.assertEquals(name, 'MyMachine')
+        self.assertEqual(name, 'MyMachine')
 
     def test_multipleLevelMountPointExtraPathInfo(self):
         url = '/other/mount/point/fsm/MyMachine/state1/to/state2'
         request = buildRequest(path=url)
         mock('config.currentConfiguration', returns=MockConfigRootUrl('/other/mount/point/'), tracker=None)
         name = getMachineNameFromRequest(request)
-        self.assertEquals(name, 'MyMachine')
+        self.assertEqual(name, 'MyMachine')

--- a/test/fantasm_tests/helpers.py
+++ b/test/fantasm_tests/helpers.py
@@ -81,10 +81,10 @@ class LoggingDouble(object):
 
     def _log(self, level, message, *args, **kwargs):
         self.count[level] += 1
-        if not isinstance(message, basestring):
+        if not isinstance(message, str):
             try:
                 message = str(message)
-            except Exception, e:
+            except Exception as e:
                 message = 'logging error'
                 args = ()
         try:
@@ -159,7 +159,7 @@ def runQueuedTasks(queueName='default', assertTasks=True, tasksOverride=None, sp
                 if retries.get(task['name'], 0) > maxRetries:
                     continue
 
-            if task.has_key('eta'):
+            if 'eta' in task:
 
                 UTC_OFFSET_TIMEDELTA = datetime.datetime.utcnow() - datetime.datetime.now()
                 now = datetime.datetime.utcfromtimestamp(time.time())
@@ -291,7 +291,7 @@ def getCounts(machineConfig):
     NOTE: relies on the config._StateConfig and FSMState instances sharing the FSMActions
     """
     counts = {}
-    for stateName, state in machineConfig.states.items():
+    for stateName, state in list(machineConfig.states.items()):
         if state.continuation:
             counts[state.name] = {'entry': (state.entry or ZeroCountMock).count,
                                   'continuation': (state.action or ZeroCountMock).ccount,
@@ -311,7 +311,7 @@ def getCounts(machineConfig):
                                   'action': (state.action or ZeroCountMock).count,
                                   'exit': (state.exit or ZeroCountMock).count}
 
-    for transition in machineConfig.transitions.values():
+    for transition in list(machineConfig.transitions.values()):
         counts['%s--%s' % (transition.fromState.name, transition.event)] = {
             'action': (transition.action or ZeroCountMock).count
         }
@@ -349,16 +349,16 @@ def overrideTaskRetryLimit(machineConfig, overrides):
     @param machineConfig: a config._MachineConfig instance
     @param overrides: a dict of {'transitionName' : task_retry_limit} to override
     """
-    for (transitionName, taskRetryLimit) in overrides.items():
+    for (transitionName, taskRetryLimit) in list(overrides.items()):
         transition = machineConfig.transitions[transitionName]
         transition.taskRetryLimit = taskRetryLimit
 
 def buildRequest(method='GET', get_args=None, post_args=None, referrer=None,
                   path=None, cookies=None, host=None, port=None):
     """ Builds a request suitable for view.initialize(). """
-    from urllib import urlencode
-    from Cookie import BaseCookie
-    from StringIO import StringIO
+    from urllib.parse import urlencode
+    from http.cookies import BaseCookie
+    from io import StringIO
 
     if not get_args:
         get_args = {}

--- a/test/fantasm_tests/helpers.py
+++ b/test/fantasm_tests/helpers.py
@@ -27,7 +27,7 @@ from google.appengine.api.taskqueue.taskqueue import TaskAlreadyExistsError
 os.environ['APPLICATION_ID'] = 'fantasm'
 APP_ID = os.environ['APPLICATION_ID']
 
-class TaskDouble(object):
+class TaskDouble:
     """ TaskDouble is a mock for google.appengine.api.taskqueue.Task """
     def __init__(self, url, params=None, name=None, transactional=False, method='POST', countdown=0):
         """ Initialize MockTask """
@@ -42,12 +42,12 @@ class TaskDouble(object):
         """Adds this Task to a queue. See Queue.add."""
         return TaskQueueDouble(queue_name).add(self, transactional=transactional)
 
-class TaskQueueDouble(object):
+class TaskQueueDouble:
     """ TaskQueueDouble is a mock for google.appengine.api.lab.taskqueue.Queue """
 
     def __init__(self, name='default'):
         """ Initialize TaskQueueDouble object """
-        self.tasknames = set([])
+        self.tasknames = set()
         self.tasks = []
         self.name = name
 
@@ -73,7 +73,7 @@ class TaskQueueDouble(object):
         """ purge all tasks in queue """
         self.tasks = []
 
-class LoggingDouble(object):
+class LoggingDouble:
 
     def __init__(self):
         self.count = defaultdict(int)
@@ -219,10 +219,10 @@ def runQueuedTasks(queueName='default', assertTasks=True, tasksOverride=None, sp
 
     return runList
 
-class ConfigurationMock(object):
+class ConfigurationMock:
     """ A mock object that looks like a config._Configuration instance """
     def __init__(self, machines):
-        self.machines = dict([(m.name, m) for m in machines])
+        self.machines = {m.name: m for m in machines}
 
 def getFSMFactoryByFilename(filename):
     """ Returns an FSM instance
@@ -277,7 +277,7 @@ def setUpByString(obj, yaml, machineName=None, instanceName=None):
     setUpByFilename(obj, f.name, machineName=machineName, instanceName=instanceName)
     f.close()
 
-class ZeroCountMock(object):
+class ZeroCountMock:
     count = 0
     fcount = 0
     ccount = 0
@@ -312,7 +312,7 @@ def getCounts(machineConfig):
                                   'exit': (state.exit or ZeroCountMock).count}
 
     for transition in list(machineConfig.transitions.values()):
-        counts['%s--%s' % (transition.fromState.name, transition.event)] = {
+        counts['{}--{}'.format(transition.fromState.name, transition.event)] = {
             'action': (transition.action or ZeroCountMock).count
         }
 

--- a/test/fantasm_tests/idempotency_test.py
+++ b/test/fantasm_tests/idempotency_test.py
@@ -66,11 +66,11 @@ state_machines:
 class SimpleModel( db.Model ):
     pass
 
-class SimpleFinalAction( object ):
+class SimpleFinalAction:
     def execute(self, context, obj):
         SimpleModel().put()
 
-class SimpleAction( object ):
+class SimpleAction:
     def execute(self, context, obj):
         SimpleModel().put()
         return 'ok'
@@ -84,7 +84,7 @@ class ContinuationAction( DatastoreContinuationFSMAction ):
             time.sleep(random.uniform(0.0, 1.0))
             return 'ok'
 
-class FanInAction( object ):
+class FanInAction:
     def execute(self, contexts, obj):
         keys = []
         for ctx in contexts:
@@ -107,12 +107,12 @@ class TaskDoubleExecutionTest( AppEngineTestCase ):
     the framework successfully handle this.
     """
     def setUp(self):
-        super(TaskDoubleExecutionTest, self).setUp()
+        super().setUp()
         setUpByString(self, SIMPLE_MACHINE, machineName='SimpleMachine')
         mock('config.currentConfiguration', returns=self.currentConfig, tracker=None)
 
     def tearDown(self):
-        super(TaskDoubleExecutionTest, self).tearDown()
+        super().tearDown()
         restore()
 
     def test(self):
@@ -135,7 +135,7 @@ class FanInTxnException( AppEngineTestCase ):
     the framework successfully handle this.
     """
     def setUp(self):
-        super(FanInTxnException, self).setUp()
+        super().setUp()
         setUpByString(self, FAN_IN_MACHINE, machineName='FanInMachine')
         mock('config.currentConfiguration', returns=self.currentConfig, tracker=None)
         for i in range(20):
@@ -144,7 +144,7 @@ class FanInTxnException( AppEngineTestCase ):
         memcache.set('raise', True)
 
     def tearDown(self):
-        super(FanInTxnException, self).tearDown()
+        super().tearDown()
         restore()
 
     def test(self):
@@ -157,7 +157,7 @@ class FanInTxnException( AppEngineTestCase ):
 class FanInMergeJoinDispatchTest( AppEngineTestCase ):
 
     def setUp(self):
-        super(FanInMergeJoinDispatchTest, self).setUp()
+        super().setUp()
         setUpByString(self, FAN_IN_MACHINE, machineName='FanInMachine', instanceName='foo')
         mock('config.currentConfiguration', returns=self.currentConfig, tracker=None)
         for i in range(20):
@@ -193,7 +193,7 @@ class FanInMergeJoinDispatchTest( AppEngineTestCase ):
 
     def tearDown(self):
         restore()
-        super(FanInMergeJoinDispatchTest, self).tearDown()
+        super().tearDown()
 
     def test_run_twice(self):
         self.setUpContext()
@@ -209,7 +209,7 @@ class FanInMergeJoinDispatchTest( AppEngineTestCase ):
 class FanInQueueDispatchTest( AppEngineTestCase ):
 
     def setUp(self):
-        super(FanInQueueDispatchTest, self).setUp()
+        super().setUp()
         setUpByString(self, FAN_IN_MACHINE, machineName='FanInMachine', instanceName='foo')
         mock('config.currentConfiguration', returns=self.currentConfig, tracker=None)
         for i in range(20):
@@ -228,7 +228,7 @@ class FanInQueueDispatchTest( AppEngineTestCase ):
 
     def tearDown(self):
         restore()
-        super(FanInQueueDispatchTest, self).tearDown()
+        super().tearDown()
 
     def test_run_twice(self):
         self.setUpContext()

--- a/test/fantasm_tests/integration_test.py
+++ b/test/fantasm_tests/integration_test.py
@@ -33,7 +33,7 @@ class RunTasksBaseTest(AppEngineTestCase):
     METHOD = 'GET'
 
     def setUp(self):
-        super(RunTasksBaseTest, self).setUp()
+        super().setUp()
         for i in range(10):
             TestModel(key_name=str(i)).put()
             nkey = ndb_key.Key('NDBTestModel', str(i))
@@ -43,7 +43,7 @@ class RunTasksBaseTest(AppEngineTestCase):
         self.maxDiff = None
 
     def tearDown(self):
-        super(RunTasksBaseTest, self).tearDown()
+        super().tearDown()
         restore()
 
     def setUpMock(self):
@@ -66,7 +66,7 @@ class LoggingTests( RunTasksBaseTest ):
     FILENAME = 'test-TaskQueueFSMTests.yaml'
 
     def setUp(self):
-        super(LoggingTests, self).setUp()
+        super().setUp()
         self.context.initialize()
         self.context.logger.persistentLogging = True
 
@@ -119,11 +119,11 @@ class ParamsTests(RunTasksBaseTest):
     MACHINE_NAME = 'ContextRecorder'
 
     def setUp(self):
-        super(ParamsTests, self).setUp()
+        super().setUp()
         ContextRecorder.CONTEXTS = []
 
     def tearDown(self):
-        super(ParamsTests, self).tearDown()
+        super().tearDown()
         ContextRecorder.CONTEXTS = []
 
     def _test_not_a_list(self, method):
@@ -257,11 +257,11 @@ class HeadersTests(RunTasksBaseTest):
     MACHINE_NAME = 'TaskQueueFSMTests'
 
     def setUp(self):
-        super(HeadersTests, self).setUp()
+        super().setUp()
         ContextRecorder.CONTEXTS = []
 
     def tearDown(self):
-        super(HeadersTests, self).tearDown()
+        super().tearDown()
         ContextRecorder.CONTEXTS = []
 
     def test_headers(self):
@@ -406,7 +406,7 @@ class RunTasksTests_DatastoreFSMContinuationQueueTests(RunTasksBaseTest):
     MACHINE_NAME = 'DatastoreFSMContinuationQueueTests'
 
     def setUp(self):
-        super(RunTasksTests_DatastoreFSMContinuationQueueTests, self).setUp()
+        super().setUp()
 
         import google.appengine.api.taskqueue.taskqueue_stub as taskqueue_stub
         import google.appengine.api.apiproxy_stub_map as apiproxy_stub_map
@@ -451,7 +451,7 @@ class RunTasksTests_NDBDatastoreFSMContinuationQueueTests(RunTasksBaseTest):
     MACHINE_NAME = 'NDBDatastoreFSMContinuationQueueTests'
 
     def setUp(self):
-        super(RunTasksTests_NDBDatastoreFSMContinuationQueueTests, self).setUp()
+        super().setUp()
 
         import google.appengine.api.taskqueue.taskqueue_stub as taskqueue_stub
         import google.appengine.api.apiproxy_stub_map as apiproxy_stub_map
@@ -495,11 +495,11 @@ class RunTasksTests_FileFSMContinuationTests(RunTasksBaseTest):
     MACHINE_NAME = 'FileFSMContinuationTests'
 
     def setUp(self):
-        super(RunTasksTests_FileFSMContinuationTests, self).setUp()
+        super().setUp()
         TestFileContinuationFSMAction.CONTEXTS = []
 
     def tearDown(self):
-        super(RunTasksTests_FileFSMContinuationTests, self).tearDown()
+        super().tearDown()
         TestFileContinuationFSMAction.CONTEXTS = []
 
     def test_FileFSMContinuationTests(self):
@@ -535,12 +535,12 @@ class RunTasksTests_DoubleContinuationTests(RunTasksBaseTest):
     MACHINE_NAME = 'DoubleContinuationTests'
 
     def setUp(self):
-        super(RunTasksTests_DoubleContinuationTests, self).setUp()
+        super().setUp()
         DoubleContinuation1.CONTEXTS = []
         DoubleContinuation2.CONTEXTS = []
 
     def tearDown(self):
-        super(RunTasksTests_DoubleContinuationTests, self).tearDown()
+        super().tearDown()
         DoubleContinuation1.CONTEXTS = []
         DoubleContinuation2.CONTEXTS = []
 
@@ -697,11 +697,11 @@ class RunTasksTests_DatastoreFSMContinuationFanInAndForkTests(RunTasksBaseTest):
     MACHINE_NAME = 'DatastoreFSMContinuationFanInAndForkTests'
 
     def setUp(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInAndForkTests, self).setUp()
+        super().setUp()
         CountExecuteCallsFanIn.CONTEXTS = []
 
     def tearDown(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInAndForkTests, self).tearDown()
+        super().tearDown()
         CountExecuteCallsFanIn.CONTEXTS = []
 
     def test_DatastoreFSMContinuationTests(self):
@@ -800,11 +800,11 @@ class RunTasksTests_DatastoreFSMContinuationFanInTests(RunTasksBaseTest):
     MACHINE_NAME = 'DatastoreFSMContinuationFanInTests'
 
     def setUp(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInTests, self).setUp()
+        super().setUp()
         CountExecuteCallsFanIn.CONTEXTS = []
 
     def tearDown(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInTests, self).tearDown()
+        super().tearDown()
         CountExecuteCallsFanIn.CONTEXTS = []
 
     def test_DatastoreFSMContinuationFanInTests(self):
@@ -847,11 +847,11 @@ class RunTasksTests_DatastoreFSMContinuationFanInGroupDefaultTests(RunTasksBaseT
     MACHINE_NAME = 'DatastoreFSMContinuationFanInGroupDefaultTests'
 
     def setUp(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInGroupDefaultTests, self).setUp()
+        super().setUp()
         CountExecuteCallsFanIn.CONTEXTS = []
 
     def tearDown(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInGroupDefaultTests, self).tearDown()
+        super().tearDown()
         CountExecuteCallsFanIn.CONTEXTS = []
 
     def test_DatastoreFSMContinuationFanInTests(self):
@@ -887,11 +887,11 @@ class RunTasksTests_DatastoreFSMContinuationFanInGroupTests(RunTasksBaseTest):
     MACHINE_NAME = 'DatastoreFSMContinuationFanInGroupTests'
 
     def setUp(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInGroupTests, self).setUp()
+        super().setUp()
         CountExecuteCallsFanIn.CONTEXTS = []
 
     def tearDown(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInGroupTests, self).tearDown()
+        super().tearDown()
         CountExecuteCallsFanIn.CONTEXTS = []
 
     def test_DatastoreFSMContinuationFanInTests(self):
@@ -935,9 +935,9 @@ class RunTasksTests_DatastoreFSMContinuationFanInTests_memcache_problems(RunTask
     MACHINE_NAME = 'DatastoreFSMContinuationFanInTests'
 
     def setUp(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInTests_memcache_problems, self).setUp()
+        super().setUp()
         self.loggingDouble = getLoggingDouble()
-        class BreakReadLock( object ):
+        class BreakReadLock:
             def execute(self, context, obj):
                 from google.appengine.api import memcache
                 lockKey = 'instanceName--state-continuation--next-event--state-fan-in--step-2-lock-1'
@@ -952,7 +952,7 @@ class RunTasksTests_DatastoreFSMContinuationFanInTests_memcache_problems(RunTask
         ReadWriteLock.BUSY_WAIT_ITERS = 2
 
     def tearDown(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInTests_memcache_problems, self).tearDown()
+        super().tearDown()
         CountExecuteCallsFanIn.CONTEXTS = []
         ReadWriteLock.BUSY_WAIT_ITER_SECS = ReadWriteLock._BUSY_WAIT_ITER_SECS
         ReadWriteLock.BUSY_WAIT_ITERS = ReadWriteLock._BUSY_WAIT_ITERS
@@ -1011,7 +1011,7 @@ class RunTasksTests_DatastoreFSMContinuationFanInTests_fail_post_fan_in(RunTasks
     MACHINE_NAME = 'DatastoreFSMContinuationFanInTests'
 
     def setUp(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInTests_fail_post_fan_in, self).setUp()
+        super().setUp()
         CountExecuteCallsFanIn.CONTEXTS = []
         ReadWriteLock._BUSY_WAIT_ITER_SECS = ReadWriteLock.BUSY_WAIT_ITERS
         ReadWriteLock.BUSY_WAIT_ITER_SECS = 0
@@ -1020,7 +1020,7 @@ class RunTasksTests_DatastoreFSMContinuationFanInTests_fail_post_fan_in(RunTasks
         self.context['UNITTEST_RAISE_AFTER_FAN_IN'] = True
 
     def tearDown(self):
-        super(RunTasksTests_DatastoreFSMContinuationFanInTests_fail_post_fan_in, self).tearDown()
+        super().tearDown()
         CountExecuteCallsFanIn.CONTEXTS = []
         ReadWriteLock.BUSY_WAIT_ITER_SECS = ReadWriteLock._BUSY_WAIT_ITER_SECS
         ReadWriteLock.BUSY_WAIT_ITERS = ReadWriteLock._BUSY_WAIT_ITERS

--- a/test/fantasm_tests/integration_test.py
+++ b/test/fantasm_tests/integration_test.py
@@ -170,13 +170,13 @@ class ParamsTests(RunTasksBaseTest):
         self.context['bool2'] = True
         self.context['str'] = 'abc'
         self.context['str_as_unicode'] = 'abc'
-        self.context['unicode'] = u'\xe8' # MUST be context_types
+        self.context['unicode'] = '\xe8' # MUST be context_types
         self.context['list_of_str'] = ['a', 'b', 'c']
         self.context['list_of_str_len_1'] = ['a']
         self.context['list_of_db_Key'] = [models[0].key(), models[1].key(), models[2].key()]
         self.context['list_of_db_Key_len_1'] = [models[0].key()]
         self.context['list_of_mixed'] = ['a', 1, 'b', 2]
-        self.context['list_of_unicode'] = [u'\xe8', u'\xe9'] # MUST be context_types
+        self.context['list_of_unicode'] = ['\xe8', '\xe9'] # MUST be context_types
         self.context['dict_int_keys'] = {1: 1, 2: 2} # BAD!!!! not defined in context_types
         self.context['dict_int_keys_defined_in_context_types'] = {1: 1, 2: 2}
         self.context['dict_str_keys'] = {'a': 1, 'b': 2} # BAD!!!! not defined in context_types
@@ -213,28 +213,28 @@ class ParamsTests(RunTasksBaseTest):
                            'list_of_custom': [CustomImpl(a="A", b="B"), CustomImpl(a="AA", b="BB")],
                            'list_of_custom_len_1': [CustomImpl(a="A", b="B")],
                            'db_Key': 'agdmYW50YXNtchALEglUZXN0TW9kZWwiATAM',
-                           'db_Key_defined_in_context_types': datastore_types.Key.from_path(u'TestModel', u'0', _app=u'fantasm'),
+                           'db_Key_defined_in_context_types': datastore_types.Key.from_path('TestModel', '0', _app='fantasm'),
                            'char': 'a',
-                           'unicode': u'\xe8',
+                           'unicode': '\xe8',
                            'bool1': False,
                            'bool2': True,
                            'str': 'abc',
-                           'str_as_unicode': u'abc',
+                           'str_as_unicode': 'abc',
                            'list_of_str': ['a', 'b', 'c'],
                            'list_of_str_len_1': ['a'],
-                           'list_of_db_Key': [datastore_types.Key.from_path(u'TestModel', u'0', _app=u'fantasm'),
-                                              datastore_types.Key.from_path(u'TestModel', u'1', _app=u'fantasm'),
-                                              datastore_types.Key.from_path(u'TestModel', u'2', _app=u'fantasm')],
-                           'list_of_db_Key_len_1': [datastore_types.Key.from_path(u'TestModel', u'0', _app=u'fantasm')],
-                           'list_of_unicode': [u'\xe8', u'\xe9'],
+                           'list_of_db_Key': [datastore_types.Key.from_path('TestModel', '0', _app='fantasm'),
+                                              datastore_types.Key.from_path('TestModel', '1', _app='fantasm'),
+                                              datastore_types.Key.from_path('TestModel', '2', _app='fantasm')],
+                           'list_of_db_Key_len_1': [datastore_types.Key.from_path('TestModel', '0', _app='fantasm')],
+                           'list_of_unicode': ['\xe8', '\xe9'],
                            'list_of_mixed': ['a', '1', 'b', '2'],
                            'dict_int_keys': '{"1": 1, "2": 2}',
                            'dict_int_keys_defined_in_context_types': {"1": 1, "2": 2},
                            'dict_str_keys': '{"a": 1, "b": 2}',
                            'dict_str_keys_defined_in_context_types': {"a": 1, "b": 2},
                            'dict_db_Key': '{"a": {"__db.Key__": true, "key": "agdmYW50YXNtchALEglUZXN0TW9kZWwiATEM"}}',
-                           'dict_db_Key_defined_in_context_types': {'a': datastore_types.Key.from_path(u'TestModel', u'1', _app=u'fantasm')},
-                           'unicode2': u"  Mik\xe9 ,  Br\xe9\xe9 ,  Michael.Bree-1@gmail.com ,  Montr\xe9al  ",
+                           'dict_db_Key_defined_in_context_types': {'a': datastore_types.Key.from_path('TestModel', '1', _app='fantasm')},
+                           'unicode2': "  Mik\xe9 ,  Br\xe9\xe9 ,  Michael.Bree-1@gmail.com ,  Montr\xe9al  ",
                            '__step__': 1,
 
                            # NDB Key stuff
@@ -611,15 +611,15 @@ class RunTasksTests_DoubleContinuationTests(RunTasksBaseTest):
             ], DoubleContinuation1.CONTEXTS
         )
         self.assertEqual([
-            {'c2': 'a', u'c1': u'1', u'__step__': 2},
-            {'c2': 'a', u'c1': u'2', u'__ge__': {u'0': 1}, u'__step__': 2},
-            {'c2': 'b', u'c1': u'1', u'__ge__': {u'1': 1}, u'__step__': 2},
-            {'c2': 'a', u'c1': u'3', u'__ge__': {u'0': 2}, u'__step__': 2},
-            {'c2': 'b', u'c1': u'2', u'__ge__': {u'1': 1, u'0': 1}, u'__step__': 2},
-            {'c2': 'c', u'c1': u'1', u'__ge__': {u'1': 2}, u'__step__': 2},
-            {'c2': 'b', u'c1': u'3', u'__ge__': {u'1': 1, u'0': 2}, u'__step__': 2},
-            {'c2': 'c', u'c1': u'2', u'__ge__': {u'1': 2, u'0': 1}, u'__step__': 2},
-            {'c2': 'c', u'c1': u'3', u'__ge__': {u'1': 2, u'0': 2}, u'__step__': 2}
+            {'c2': 'a', 'c1': '1', '__step__': 2},
+            {'c2': 'a', 'c1': '2', '__ge__': {'0': 1}, '__step__': 2},
+            {'c2': 'b', 'c1': '1', '__ge__': {'1': 1}, '__step__': 2},
+            {'c2': 'a', 'c1': '3', '__ge__': {'0': 2}, '__step__': 2},
+            {'c2': 'b', 'c1': '2', '__ge__': {'1': 1, '0': 1}, '__step__': 2},
+            {'c2': 'c', 'c1': '1', '__ge__': {'1': 2}, '__step__': 2},
+            {'c2': 'b', 'c1': '3', '__ge__': {'1': 1, '0': 2}, '__step__': 2},
+            {'c2': 'c', 'c1': '2', '__ge__': {'1': 2, '0': 1}, '__step__': 2},
+            {'c2': 'c', 'c1': '3', '__ge__': {'1': 2, '0': 2}, '__step__': 2}
             ], DoubleContinuation2.CONTEXTS
         )
 
@@ -726,16 +726,16 @@ class RunTasksTests_DatastoreFSMContinuationFanInAndForkTests(RunTasksBaseTest):
         self.assertEqual(0, _FantasmFanIn.all(namespace='').count())
         # pylint: disable=C0301
         # - long lines are much clearer in htis case
-        self.assertEqual([{u'__crs__': 2, u'__crc__': 4, '__cc__': False, u'__count__': 2, u'key': datastore_types.Key.from_path(u'TestModel', '3', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 4, '__cc__': False, u'__count__': 2, u'key': datastore_types.Key.from_path(u'TestModel', '2', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 6, '__cc__': False, u'__count__': 3, u'key': datastore_types.Key.from_path(u'TestModel', '5', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 6, '__cc__': False, u'__count__': 3, u'key': datastore_types.Key.from_path(u'TestModel', '4', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 8, '__cc__': False, u'__count__': 4, u'key': datastore_types.Key.from_path(u'TestModel', '7', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 8, '__cc__': False, u'__count__': 4, u'key': datastore_types.Key.from_path(u'TestModel', '6', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 10, '__cc__': False, u'__count__': 5, u'key': datastore_types.Key.from_path(u'TestModel', '9', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 10, '__cc__': False, u'__count__': 5, u'key': datastore_types.Key.from_path(u'TestModel', '8', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 2, '__cc__': False, u'__count__': 1, u'key': datastore_types.Key.from_path(u'TestModel', '1', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1},
-                          {u'__crs__': 2, u'__crc__': 2, '__cc__': False, u'__count__': 1, u'key': datastore_types.Key.from_path(u'TestModel','0', _app=u'fantasm'), 'data': {'a': 'b'}, u'__step__': 1, u'__ix__': 1}], CountExecuteCallsFanIn.CONTEXTS)
+        self.assertEqual([{'__crs__': 2, '__crc__': 4, '__cc__': False, '__count__': 2, 'key': datastore_types.Key.from_path('TestModel', '3', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 4, '__cc__': False, '__count__': 2, 'key': datastore_types.Key.from_path('TestModel', '2', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 6, '__cc__': False, '__count__': 3, 'key': datastore_types.Key.from_path('TestModel', '5', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 6, '__cc__': False, '__count__': 3, 'key': datastore_types.Key.from_path('TestModel', '4', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 8, '__cc__': False, '__count__': 4, 'key': datastore_types.Key.from_path('TestModel', '7', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 8, '__cc__': False, '__count__': 4, 'key': datastore_types.Key.from_path('TestModel', '6', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 10, '__cc__': False, '__count__': 5, 'key': datastore_types.Key.from_path('TestModel', '9', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 10, '__cc__': False, '__count__': 5, 'key': datastore_types.Key.from_path('TestModel', '8', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 2, '__cc__': False, '__count__': 1, 'key': datastore_types.Key.from_path('TestModel', '1', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1},
+                          {'__crs__': 2, '__crc__': 2, '__cc__': False, '__count__': 1, 'key': datastore_types.Key.from_path('TestModel','0', _app='fantasm'), 'data': {'a': 'b'}, '__step__': 1, '__ix__': 1}], CountExecuteCallsFanIn.CONTEXTS)
 
 class RunTasksTests_DatastoreFSMContinuationFanInAndForkTests_POST(
                                                             RunTasksTests_DatastoreFSMContinuationFanInAndForkTests):
@@ -830,11 +830,11 @@ class RunTasksTests_DatastoreFSMContinuationFanInTests(RunTasksBaseTest):
                           'state-fan-in--next-event': {'action': 0}},
                  getCounts(self.machineConfig))
         # pylint: disable=C0301
-        self.assertEqual([{u'__crs__': 2, u'__crc__': 4, '__cc__': False, u'__ix__': 1, u'__count__': 2, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'2', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'3', _app=u'fantasm')]},
-                          {u'__crs__': 2, u'__crc__': 6, '__cc__': False, u'__ix__': 1, u'__count__': 3, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'4', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'5', _app=u'fantasm')]},
-                          {u'__crs__': 2, u'__crc__': 8, '__cc__': False, u'__ix__': 1, u'__count__': 4, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'6', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'7', _app=u'fantasm')]},
-                          {u'__crs__': 2, u'__crc__': 10, '__cc__': False, u'__ix__': 1, u'__count__': 5, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'8', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'9', _app=u'fantasm')]},
-                          {u'__crs__': 2, u'__crc__': 2, '__cc__': False, u'__ix__': 1, u'__count__': 1, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'0', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'1', _app=u'fantasm')]}], CountExecuteCallsFanIn.CONTEXTS)
+        self.assertEqual([{'__crs__': 2, '__crc__': 4, '__cc__': False, '__ix__': 1, '__count__': 2, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '2', _app='fantasm'), datastore_types.Key.from_path('TestModel', '3', _app='fantasm')]},
+                          {'__crs__': 2, '__crc__': 6, '__cc__': False, '__ix__': 1, '__count__': 3, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '4', _app='fantasm'), datastore_types.Key.from_path('TestModel', '5', _app='fantasm')]},
+                          {'__crs__': 2, '__crc__': 8, '__cc__': False, '__ix__': 1, '__count__': 4, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '6', _app='fantasm'), datastore_types.Key.from_path('TestModel', '7', _app='fantasm')]},
+                          {'__crs__': 2, '__crc__': 10, '__cc__': False, '__ix__': 1, '__count__': 5, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '8', _app='fantasm'), datastore_types.Key.from_path('TestModel', '9', _app='fantasm')]},
+                          {'__crs__': 2, '__crc__': 2, '__cc__': False, '__ix__': 1, '__count__': 1, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '0', _app='fantasm'), datastore_types.Key.from_path('TestModel', '1', _app='fantasm')]}], CountExecuteCallsFanIn.CONTEXTS)
         self.assertEqual(0, _FantasmFanIn.all(namespace='').count())
         self.assertEqual(10, ResultModel.get_by_key_name(self.context.instanceName).total)
 
@@ -993,11 +993,11 @@ class RunTasksTests_DatastoreFSMContinuationFanInTests_memcache_problems(RunTask
                           "Gave up waiting for all fan-in work items with read lock 'instanceName--state-continuation--next-event--state-fan-in--step-2-lock-1'.",
                           "Gave up waiting for all fan-in work items with read lock 'instanceName--state-continuation--next-event--state-fan-in--step-2-lock-1'."], self.loggingDouble.messages['critical'])
         # pylint: disable=C0301
-        self.assertEqual([{u'__crs__': 2, u'__crc__': 4, u'__cc__': False, u'__ix__': 1, u'__count__': 2, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'2', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'3', _app=u'fantasm')]},
-                          {u'__crs__': 2, u'__crc__': 6, u'__cc__': False, u'__ix__': 1, u'__count__': 3, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'4', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'5', _app=u'fantasm')]},
-                          {u'__crs__': 2, u'__crc__': 8, u'__cc__': False, u'__ix__': 1, u'__count__': 4, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'6', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'7', _app=u'fantasm')]},
-                          {u'__crs__': 2, u'__crc__': 10, u'__cc__': False, u'__ix__': 1, u'__count__': 5, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'8', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'9', _app=u'fantasm')]},
-                          {u'__crs__': 2, u'__crc__': 2, u'__cc__': False, u'__ix__': 1, u'__count__': 1, u'__step__': 2, 'fan-me-in': [datastore_types.Key.from_path(u'TestModel', u'0', _app=u'fantasm'), datastore_types.Key.from_path(u'TestModel', u'1', _app=u'fantasm')]}], CountExecuteCallsFanIn.CONTEXTS)
+        self.assertEqual([{'__crs__': 2, '__crc__': 4, '__cc__': False, '__ix__': 1, '__count__': 2, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '2', _app='fantasm'), datastore_types.Key.from_path('TestModel', '3', _app='fantasm')]},
+                          {'__crs__': 2, '__crc__': 6, '__cc__': False, '__ix__': 1, '__count__': 3, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '4', _app='fantasm'), datastore_types.Key.from_path('TestModel', '5', _app='fantasm')]},
+                          {'__crs__': 2, '__crc__': 8, '__cc__': False, '__ix__': 1, '__count__': 4, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '6', _app='fantasm'), datastore_types.Key.from_path('TestModel', '7', _app='fantasm')]},
+                          {'__crs__': 2, '__crc__': 10, '__cc__': False, '__ix__': 1, '__count__': 5, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '8', _app='fantasm'), datastore_types.Key.from_path('TestModel', '9', _app='fantasm')]},
+                          {'__crs__': 2, '__crc__': 2, '__cc__': False, '__ix__': 1, '__count__': 1, '__step__': 2, 'fan-me-in': [datastore_types.Key.from_path('TestModel', '0', _app='fantasm'), datastore_types.Key.from_path('TestModel', '1', _app='fantasm')]}], CountExecuteCallsFanIn.CONTEXTS)
         self.assertEqual(0, _FantasmFanIn.all(namespace='').count())
         self.assertEqual(10, ResultModel.get_by_key_name(self.context.instanceName).total)
 
@@ -1509,9 +1509,9 @@ class FinalStateCanEmitEventTests(RunTasksBaseTest):
         self.context.initialize() # queues the first task
         ran = runQueuedTasks(queueName=self.context.queueName)
         counts = getCounts(self.machineConfig)
-        self.assertEquals(1, counts['InitialState']['action'])
-        self.assertEquals(1, counts['OptionalFinalState']['action'])
-        self.assertEquals(1, counts['FinalState']['action'])
+        self.assertEqual(1, counts['InitialState']['action'])
+        self.assertEqual(1, counts['OptionalFinalState']['action'])
+        self.assertEqual(1, counts['FinalState']['action'])
 
 class SpawnMachinesTests(RunTasksBaseTest):
 
@@ -1528,7 +1528,7 @@ class SpawnMachinesTests(RunTasksBaseTest):
         self.assertTrue('instanceName--pseudo-init--pseudo-init--SpawnTests-InitialState--step-0--startStateMachine-0' in ran)
         self.assertTrue('instanceName--pseudo-init--pseudo-init--SpawnTests-InitialState--step-0--startStateMachine-1' in ran)
         self.assertTrue('instanceName--SpawnTests-InitialState--pseudo-final--pseudo-final--step-1' in ran)
-        self.assertEquals({'action': 1, 'entry': 1, 'exit': 1}, counts['SpawnTests-InitialState'])
+        self.assertEqual({'action': 1, 'entry': 1, 'exit': 1}, counts['SpawnTests-InitialState'])
 
         # FIXME: counts only considers one machine and needs to be extended
         # FIXME: spawned machines don't have an instrumented instanceName, so the tasks are difficult to compare

--- a/test/fantasm_tests/lock_test.py
+++ b/test/fantasm_tests/lock_test.py
@@ -21,7 +21,7 @@ from minimock import mock, restore
 class ReadWriteLockTest(AppEngineTestCase):
 
     def setUp(self):
-        super(ReadWriteLockTest, self).setUp()
+        super().setUp()
         self.loggingDouble = getLoggingDouble()
         self.state = State('name', None, None, None)
         self.context = FSMContext(self.state, queueName='default')
@@ -37,7 +37,7 @@ class ReadWriteLockTest(AppEngineTestCase):
         # pylint: disable=W0212
         ReadWriteLock.BUSY_WAIT_ITER_SECS = ReadWriteLock._BUSY_WAIT_ITER_SECS
         ReadWriteLock.BUSY_WAIT_ITERS = ReadWriteLock._BUSY_WAIT_ITERS
-        super(ReadWriteLockTest, self).tearDown()
+        super().tearDown()
 
     def test_indexKey(self):
         lock = ReadWriteLock('foo', self.context)
@@ -148,13 +148,13 @@ class RunOnceSemaphoreTest(AppEngineTestCase):
     TRANSACTIONAL = True
 
     def setUp(self):
-        super(RunOnceSemaphoreTest, self).setUp()
+        super().setUp()
         self.loggingDouble = getLoggingDouble()
         random.seed(0) # last step
 
     def tearDown(self):
         restore()
-        super(RunOnceSemaphoreTest, self).tearDown()
+        super().tearDown()
 
     def test_writeRunOnceSemaphore(self):
         sem = RunOnceSemaphore('foo', None)

--- a/test/fantasm_tests/log_test.py
+++ b/test/fantasm_tests/log_test.py
@@ -17,7 +17,7 @@ class LoggerTestPersistent(AppEngineTestCase):
     PERSISTENT_LOGGING = True
 
     def setUp(self):
-        super(LoggerTestPersistent, self).setUp()
+        super().setUp()
         filename = 'test-FSMContextTests.yaml'
         setUpByFilename(self, filename)
         self.context.logger.persistentLogging = self.PERSISTENT_LOGGING
@@ -100,7 +100,7 @@ class LoggerTestPersistent(AppEngineTestCase):
             self.assertEqual("{'a': 'b'}", self.loggingDouble.messages['info'][0])
 
     def test_logging_bad_object(self):
-        class StrRaises(object):
+        class StrRaises:
             def __str__(self):
                 raise Exception()
         self.context.logger.info(StrRaises())

--- a/test/fantasm_tests/models_test.py
+++ b/test/fantasm_tests/models_test.py
@@ -14,7 +14,7 @@ class TestModel(db.Model):
 class FastasmFanInTest(AppEngineTestCase):
 
     def setUp(self):
-        super(FastasmFanInTest, self).setUp()
+        super().setUp()
         self.testModel = TestModel()
         self.testModel.put()
 

--- a/test/fantasm_tests/ndb_actions.py
+++ b/test/fantasm_tests/ndb_actions.py
@@ -13,7 +13,7 @@ from fantasm.constants import CONTINUATION_RESULTS_KEY
 class NDBTestModel(ndb_model.Model):
     prop1 = ndb_model.StringProperty()
 
-class CountExecuteCalls(object):
+class CountExecuteCalls:
     def __init__(self):
         self.count = 0
         self.fails = 0
@@ -34,7 +34,7 @@ class CountExecuteCallsFinal(CountExecuteCalls):
 
 class TestDatastoreContinuationFSMAction(NDBDatastoreContinuationFSMAction):
     def __init__(self):
-        super(TestDatastoreContinuationFSMAction, self).__init__()
+        super().__init__()
         self.count = 0
         self.ccount = 0
         self.fails = 0
@@ -48,7 +48,7 @@ class TestDatastoreContinuationFSMAction(NDBDatastoreContinuationFSMAction):
         self.ccount += 1
         if self.ccount == self.cfailat:
             raise Exception()
-        return super(TestDatastoreContinuationFSMAction, self).continuation(context, obj, token=token)
+        return super().continuation(context, obj, token=token)
     def execute(self, context, obj):
         if not obj[CONTINUATION_RESULTS_KEY]:
             return None
@@ -64,7 +64,7 @@ class TestDatastoreContinuationFSMAction(NDBDatastoreContinuationFSMAction):
 
 class TestContinuationAndForkFSMAction(NDBDatastoreContinuationFSMAction):
     def __init__(self):
-        super(TestContinuationAndForkFSMAction, self).__init__()
+        super().__init__()
         self.count = 0
         self.ccount = 0
         self.fails = 0
@@ -78,7 +78,7 @@ class TestContinuationAndForkFSMAction(NDBDatastoreContinuationFSMAction):
         self.ccount += 1
         if self.ccount == self.cfailat:
             raise Exception()
-        return super(TestContinuationAndForkFSMAction, self).continuation(context, obj, token=token)
+        return super().continuation(context, obj, token=token)
     def execute(self, context, obj):
         if not obj[CONTINUATION_RESULTS_KEY]:
             return None

--- a/test/main.py
+++ b/test/main.py
@@ -5,9 +5,9 @@ import logging
 from google.appengine.ext.webapp.util import run_wsgi_app
 from google.appengine.ext import webapp
 from google.appengine.ext import db
-from complex_machine import TestModel
-import email_batch
-import backup
+from .complex_machine import TestModel
+from . import email_batch
+from . import backup
 
 # pylint: disable=C0111, C0103
 # - docstring not reqd
@@ -102,7 +102,7 @@ class Make100Models(webapp.RequestHandler):
 class Start100ComplexMachine(webapp.RequestHandler):
 
     def get(self):
-        import fantasm
+        from . import fantasm
         fantasm.fsm.startStateMachine('ComplexMachine', [{}] * 100)
 
 class SecurityToken(db.Model):
@@ -123,7 +123,7 @@ def checkSecurity(name, request):
 class Start100ComplexMachineCountdown(webapp.RequestHandler):
 
     def get(self):
-        import fantasm
+        from . import fantasm
         fantasm.fsm.startStateMachine('ComplexMachine', [{}] * 100, countdown=[i*300 for i in range(100)])
 
 class IntegrationTest(webapp.RequestHandler):
@@ -135,7 +135,7 @@ class IntegrationTest(webapp.RequestHandler):
             self.response.set_status(401)
             return
 
-        import fantasm
+        from . import fantasm
         for _ in range(10):
             fantasm.fsm.startStateMachine('ComplexMachine', [{}] * 100, countdown=[i*300 for i in range(100)])
 
@@ -148,7 +148,7 @@ class NDBIntegrationTest(webapp.RequestHandler):
             self.response.set_status(401)
             return
 
-        import fantasm
+        from . import fantasm
         for _ in range(10):
             fantasm.fsm.startStateMachine('NDBComplexMachine', [{}] * 100, countdown=[i*300 for i in range(100)])
 

--- a/test/minimock.py
+++ b/test/minimock.py
@@ -40,16 +40,16 @@ implementation is simple because most of the work is done by doctest.
 
 __all__ = ["mock", "restore", "Mock", "TraceTracker", "assert_same_trace"]
 
-import __builtin__
+import builtins
 import sys
 import inspect
 import doctest
 import re
 import textwrap
 try:
-    from cStringIO import StringIO
+    from io import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from io import StringIO
 
 # A list of mocked objects. Each item is a tuple of (original object,
 # namespace dict, object name, and a list of object attributes).
@@ -147,7 +147,7 @@ def mock(name, nsdicts=None, mock_obj=None, **kw):
             # stack[1][0] is the frame object of the caller to this function
             globals_ = stack[1][0].f_globals
             locals_ = stack[1][0].f_locals
-            nsdicts = (locals_, globals_, __builtin__.__dict__)
+            nsdicts = (locals_, globals_, builtins.__dict__)
         finally:
             del(stack)
 
@@ -237,7 +237,7 @@ class Printer(AbstractTracker):
         if len(msg) > 80:
             msg = 'Called %s(\n    %s)' % (
                 func_name, ',\n    '.join(parts))
-        print >> self.file, msg
+        print(msg, file=self.file)
 
     def set(self, obj_name, attr, value): 
         """
@@ -245,7 +245,7 @@ class Printer(AbstractTracker):
         >>> z.a = 2
         Set z.a = 2
         """
-        print >> self.file, 'Set %s.%s = %r' % (obj_name, attr, value)
+        print('Set %s.%s = %r' % (obj_name, attr, value), file=self.file)
         
 class TraceTracker(Printer):
     """
@@ -376,7 +376,7 @@ def normalize_function_parameters(text):
         re.compile(r"(\S)\s+\)"): r"\1)",
         re.compile(r",\s*(\S)"): r", \1",
         }
-    for search_pattern, replace_pattern in normalize_map.items():
+    for search_pattern, replace_pattern in list(normalize_map.items()):
         normalized_text = re.sub(
             search_pattern, replace_pattern, normalized_text)
 
@@ -445,7 +445,7 @@ class Mock(object):
             return self.mock_returns
         elif self.mock_returns_iter is not None:
             try:
-                return self.mock_returns_iter.next()
+                return next(self.mock_returns_iter)
             except StopIteration:
                 raise Exception("No more mock return values are present.")
         elif self.mock_returns_func is not None:

--- a/test/minimock.py
+++ b/test/minimock.py
@@ -212,7 +212,7 @@ def assert_same_trace(tracker, want):
     """
     assert tracker.check(want), tracker.diff(want)
     
-class AbstractTracker(object):
+class AbstractTracker:
     def __init__(self, *args, **kw):
         raise NotImplementedError
 
@@ -233,9 +233,9 @@ class Printer(AbstractTracker):
         parts = [repr(a) for a in args]
         parts.extend(
             '%s=%r' % (items) for items in sorted(kw.items()))
-        msg = 'Called %s(%s)' % (func_name, ', '.join(parts))
+        msg = 'Called {}({})'.format(func_name, ', '.join(parts))
         if len(msg) > 80:
-            msg = 'Called %s(\n    %s)' % (
+            msg = 'Called {}(\n    {})'.format(
                 func_name, ',\n    '.join(parts))
         print(msg, file=self.file)
 
@@ -245,7 +245,7 @@ class Printer(AbstractTracker):
         >>> z.a = 2
         Set z.a = 2
         """
-        print('Set %s.%s = %r' % (obj_name, attr, value), file=self.file)
+        print('Set {}.{} = {!r}'.format(obj_name, attr, value), file=self.file)
         
 class TraceTracker(Printer):
     """
@@ -256,7 +256,7 @@ class TraceTracker(Printer):
     """
     def __init__(self, *args, **kw):
         self.out = StringIO()
-        super(TraceTracker, self).__init__(self.out, *args, **kw)
+        super().__init__(self.out, *args, **kw)
         self.checker = MinimockOutputChecker()
         self.options =  doctest.ELLIPSIS
         self.options |= doctest.NORMALIZE_INDENTATION
@@ -389,7 +389,7 @@ doctest.NORMALIZE_FUNCTION_PARAMETERS = (
     doctest.register_optionflag('NORMALIZE_FUNCTION_PARAMETERS'))
 
 
-class MinimockOutputChecker(doctest.OutputChecker, object):
+class MinimockOutputChecker(doctest.OutputChecker):
     """Class for matching output of MiniMock objects against expectations.
     """
 
@@ -400,19 +400,19 @@ class MinimockOutputChecker(doctest.OutputChecker, object):
         if (optionflags & doctest.NORMALIZE_FUNCTION_PARAMETERS):
             want = normalize_function_parameters(want)
             got = normalize_function_parameters(got)
-        output_match = super(MinimockOutputChecker, self).check_output(
+        output_match = super().check_output(
             want, got, optionflags)
         return output_match
     check_output.__doc__ = doctest.OutputChecker.check_output.__doc__
 
 
-class _DefaultTracker(object):
+class _DefaultTracker:
     def __repr__(self):
         return '(default tracker)'
 DefaultTracker = _DefaultTracker()
 del _DefaultTracker
 
-class Mock(object):
+class Mock:
 
     def __init__(self, name, returns=None, returns_iter=None,
                  returns_func=None, raises=None, show_attrs=False,
@@ -431,7 +431,7 @@ class Mock(object):
         object.__setattr__(self, 'mock_tracker', tracker)
 
     def __repr__(self):
-        return '<Mock %s %s>' % (hex(id(self)), self.mock_name)
+        return '<Mock {} {}>'.format(hex(id(self)), self.mock_name)
 
     def __call__(self, *args, **kw):
         if self.mock_tracker is not None:

--- a/test/ndb_complex_machine.py
+++ b/test/ndb_complex_machine.py
@@ -4,8 +4,8 @@ import random
 import time
 import os
 import pickle
-from fantasm.action import FSMAction, NDBDatastoreContinuationFSMAction
-from fantasm.constants import CONTINUATION_RESULTS_KEY
+from .fantasm.action import FSMAction, NDBDatastoreContinuationFSMAction
+from .fantasm.constants import CONTINUATION_RESULTS_KEY
 from google.appengine.ext.ndb import model as ndb_model
 from google.appengine.ext import db
 
@@ -41,7 +41,7 @@ class MyDatastoreContinuationFSMAction(NDBDatastoreContinuationFSMAction):
 class EntryAction1(FSMAction):
     def execute(self, context, obj):
         context['foo'] = 'bar'
-        context['unicode'] = u'\xe8'
+        context['unicode'] = '\xe8'
         if 'failure' in context  and random.random() < 0.25:
             raise Exception('failure')
 

--- a/test/retry_test.py
+++ b/test/retry_test.py
@@ -1,11 +1,11 @@
 """ Test machine for built-in TaskRetryOptions. """
 
-class State1(object):
+class State1:
     
     def execute(self, context, obj):
         return 'ok'
         
-class State2(object):
+class State2:
     
     def execute(self, context, obj):
         raise Exception()

--- a/test/simple_machine.py
+++ b/test/simple_machine.py
@@ -1,7 +1,7 @@
 """ Simple machine actions """
 
 import random
-from fantasm.action import FSMAction
+from .fantasm.action import FSMAction
 
 # pylint: disable=C0111
 # - docstring not reqd
@@ -39,7 +39,7 @@ class ExitAction3(FSMAction):
 class DoAction1(FSMAction):
     def execute(self, context, obj):
         context.logger.info('DoAction1.execute()')
-        context['unicode'] = u'\xe8'
+        context['unicode'] = '\xe8'
         return 'event1'
 
 class DoAction2(FSMAction):

--- a/test/test_dynamic_queue.py
+++ b/test/test_dynamic_queue.py
@@ -4,12 +4,12 @@ Testing dynamic queue specificiation (context.setQueue())
 import os
 import logging
 
-from fantasm.action import FSMAction
+from .fantasm.action import FSMAction
 
 OK_EVENT = 'ok'
 
 def log_environ():
-    for key, value in os.environ.iteritems():
+    for key, value in os.environ.items():
         if not key.startswith('HTTP_X_APPENGINE_'):
             continue
         logging.info('%s: %s', key, value)

--- a/test/url_fanout.py
+++ b/test/url_fanout.py
@@ -1,13 +1,8 @@
 """ Url fanout actions """
-import sys
+import json
 
-if sys.version_info < (2, 7):
-    import simplejson as json
-else:
-    import json
-
-from google.appengine.ext import db
 from google.appengine.api import urlfetch
+from google.appengine.ext import db
 
 # pylint: disable=C0111, W0613
 # - docstring not reqd

--- a/test/url_fanout.py
+++ b/test/url_fanout.py
@@ -13,7 +13,7 @@ from google.appengine.api import urlfetch
 # - docstring not reqd
 # - some unused arguments
 
-class TwitterSearch(object):
+class TwitterSearch:
     """ Performs a Twitter search """
 
     def continuation(self, context, obj, token=None):

--- a/tools/teamcity/messages.py
+++ b/tools/teamcity/messages.py
@@ -12,7 +12,7 @@ class TeamcityServiceMessages:
     def message(self, messageName, **properties):
         self.output.write("\n##teamcity[" + messageName)
         for k, v in list(properties.items()):
-            self.output.write(" %s='%s'" % (k, self.escapeValue(v)))
+            self.output.write(" {}='{}'".format(k, self.escapeValue(v)))
         self.output.write("]\n")
         
     def testSuiteStarted(self, suiteName):

--- a/tools/teamcity/messages.py
+++ b/tools/teamcity/messages.py
@@ -11,7 +11,7 @@ class TeamcityServiceMessages:
     
     def message(self, messageName, **properties):
         self.output.write("\n##teamcity[" + messageName)
-        for k, v in properties.items():
+        for k, v in list(properties.items()):
             self.output.write(" %s='%s'" % (k, self.escapeValue(v)))
         self.output.write("]\n")
         

--- a/tools/teamcity/nose_report.py
+++ b/tools/teamcity/nose_report.py
@@ -20,7 +20,7 @@ class TeamcityReport(TeamcityTestResult):
     def getCtxName(self, ctx):
         if type(ctx) is types.ModuleType:
             return ctx.__name__
-        elif type(ctx) in (types.TypeType, types.ClassType):
+        elif type(ctx) in (type, type):
             return ctx.__module__ + '.' + ctx.__name__
         else:
             return str(ctx)

--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -54,7 +54,7 @@ def suite():
                     continue
                     
                 # Import the test file and find all TestClass clases inside it.
-                module_name = '%s.%s' % (module, filename[:-3])
+                module_name = '{}.{}'.format(module, filename[:-3])
                 # logging.critical('adding %s' % module_name)
                 # test_suite.addTest(unittest.TestLoader().loadTestsFromName(module_name))
                 test_module = __import__(module_name, {}, {}, filename[:-3])

--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -68,7 +68,6 @@ def suite():
 
 if __name__ == "__main__":
 
-    sys.path.insert(0, os.path.join(os.environ['APPENGINEDIR'], 'lib', 'simplejson'))
     os.environ['SERVER_SOFTWARE'] = 'Development/unittest' # to ensure correct reloading of config/FSM
 
     import sys


### PR DESCRIPTION
This is just the basic migration. I haven't ported or added any of the test runner, pylint, CI/CD publishing or anything like that.

We can come back around to that stuff when we get into the more heavy use cases of it like CS. For now, in VBC I have a very simple functional case to test it with - VBC superadmin partner delete. It's something that never gets used anymore (probably causes big problems if you delete a partner that way) but it is a nice functional test case.

@ksheasby-va 